### PR TITLE
Optimize GitHub project page

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,89 @@
+name: Bug report
+description: Report a reproducible QuotaView problem
+title: "[Bug]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve QuotaView. Do not include credentials, authentication tokens, or an unredacted `~/.codex` file.
+
+  - type: input
+    id: version
+    attributes:
+      label: QuotaView version
+      description: Find this in the release filename or app information.
+      placeholder: "0.1.5 (Build 6)"
+    validations:
+      required: true
+
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version
+      placeholder: "macOS 15.5"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: hardware
+    attributes:
+      label: Mac hardware
+      options:
+        - Apple Silicon
+        - Intel
+        - Unknown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: codex_source
+    attributes:
+      label: Codex installation
+      options:
+        - ChatGPT app
+        - Homebrew
+        - Custom executable path
+        - PATH
+        - Unknown
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Open QuotaView
+        2. Click ...
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Redacted diagnostics
+      description: Optional. Remove personal information, tokens, account responses, and local paths before posting.
+      render: shell
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Safety check
+      options:
+        - label: I have removed credentials, tokens, and other sensitive account data.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Download the latest release
+    url: https://github.com/Duoasa/QuotaView/releases/latest
+    about: Check the latest release notes and download the current build.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature request
+description: Propose a focused improvement to QuotaView
+title: "[Feature]: "
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What workflow or limitation should this change improve?
+      placeholder: "When I ..., I need ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behavior
+      description: Describe the smallest useful version of the change.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Optional. How do you handle this today?
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Menu bar
+        - Popover
+        - Settings
+        - Codex compatibility
+        - Usage data
+        - Notifications
+        - Accessibility
+        - Localization
+        - Other
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope check
+      options:
+        - label: This request does not require posting or storing authentication credentials.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+Describe the problem and the focused change that solves it.
+
+## Verification
+
+- [ ] `swift test`
+- [ ] I reviewed the affected state transitions and error handling.
+- [ ] I did not add credentials, tokens, real account responses, or local machine paths.
+- [ ] I updated English and Simplified Chinese documentation or strings when needed.
+
+## Compatibility and privacy
+
+List any Codex App Server schema assumptions, supported macOS changes, or privacy implications. Write `None` when not applicable.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Swift tests
+    runs-on: macos-15
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Show Swift version
+        run: swift --version
+
+      - name: Run tests
+        run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,12 @@ concurrency:
 jobs:
   test:
     name: Swift tests
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 15
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Show Swift version
         run: swift --version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing to QuotaView
+
+Thanks for helping improve QuotaView. Bug reports, Codex compatibility reports, focused feature proposals, documentation fixes, and tested code changes are welcome.
+
+## Before you start
+
+- Search existing issues before opening a new one.
+- Use the issue forms for bugs and feature requests.
+- Open an issue before starting a large behavioral or architectural change.
+- Never post authentication tokens, login credentials, or an unredacted `~/.codex` file.
+
+## Development setup
+
+Requirements:
+
+- macOS 14 or later
+- Swift 6 or Xcode 16+
+- ChatGPT/Codex installed and signed in for live App Server testing
+
+Clone and verify the project:
+
+```bash
+git clone https://github.com/Duoasa/QuotaView.git
+cd QuotaView
+swift test
+```
+
+Run the app:
+
+```bash
+swift run QuotaView
+```
+
+Run the read-only account probe:
+
+```bash
+swift run QuotaViewProbe
+```
+
+## Pull requests
+
+Keep pull requests focused and explain:
+
+- the problem being solved;
+- the behavior before and after the change;
+- the tests you ran;
+- any Codex App Server schema assumptions;
+- any user-facing strings or privacy implications.
+
+For user-facing changes, update both `README.md` and `README.zh-CN.md` when the documented behavior changes. Keep English and Simplified Chinese interface strings aligned.
+
+Before opening a pull request:
+
+```bash
+swift test
+```
+
+Do not add real account responses, credentials, tokens, signing identities, or local machine paths to tests or fixtures.
+
+## Compatibility principles
+
+- Treat Credits and remaining plan quota as separate values.
+- Keep the account probe read-only.
+- Do not enable quota reset consumption without idempotency, explicit result handling, and protocol compatibility tests.
+- Preserve offline, missing executable, cold-start, and App Server error handling.
+- Prefer native SwiftUI/AppKit behavior over web-based UI dependencies.
+
+## Reporting a security concern
+
+Do not open a public issue containing secrets or exploit details. Use GitHub's private vulnerability reporting option for this repository when it is available. For non-sensitive privacy or security hardening suggestions, use a regular issue.

--- a/README.md
+++ b/README.md
@@ -1,67 +1,100 @@
-<img src="Resources/QuotaView-ICON.png" alt="QuotaView icon" width="200">
+<p align="center">
+  <img src="Resources/QuotaView-ICON.png" alt="QuotaView icon" width="160">
+</p>
 
-[**English**](README.md) | [简体中文](README.zh-CN.md)
+<h1 align="center">QuotaView</h1>
 
-# QuotaView
+<p align="center">
+  See your Codex quota, Credits balance, token usage, and reset time from the macOS menu bar.
+</p>
 
-QuotaView is a native macOS menu bar app that puts AI service quotas, usage, balances, and reset times in one place. Version 0.1.5 starts with the locally signed-in Codex account, with support for more AI providers planned.
+<p align="center">
+  <a href="https://github.com/Duoasa/QuotaView/releases/latest"><img alt="Latest release" src="https://img.shields.io/github/v/release/Duoasa/QuotaView?display_name=tag&sort=semver"></a>
+  <a href="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml/badge.svg"></a>
+  <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111?logo=apple">
+  <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white">
+</p>
 
-QuotaView does not scrape web pages or read, copy, or store login credentials from `~/.codex`. It starts the local `codex app-server` process and reads account data through its official JSON-RPC interface.
+<p align="center">
+  <a href="https://github.com/Duoasa/QuotaView/releases/latest"><strong>Download the latest release</strong></a>
+  ·
+  <a href="#privacy-by-design">Privacy</a>
+  ·
+  <a href="#build-and-test">Build from source</a>
+</p>
 
-## Preview
+<p align="center">
+  <strong>English</strong> · <a href="README.zh-CN.md">简体中文</a>
+</p>
 
 ![QuotaView app preview](Resources/QuotaView-Preview.jpg)
 
-## Download
+QuotaView is a focused, native macOS menu bar app for the Codex account already signed in on your Mac. It shows the information you need before a limit interrupts your work, without scraping web pages or reading login credentials from `~/.codex`.
 
-Download `QuotaView-v0.1.5.zip` from [GitHub Releases](https://github.com/Duoasa/QuotaView/releases), unzip it, and open `QuotaView.app`.
+## Why QuotaView
 
-The current v0.1.5 download is Build 6, a hotfix that corrects the availability badge shape and removes color bleeding around its background.
+| | |
+| --- | --- |
+| **At a glance** | See used and remaining quota, reset countdowns, Credits, and availability without leaving your current app. |
+| **Local connection** | Communicates with a locally launched `codex app-server` process through its JSON-RPC interface. |
+| **Native macOS** | Built with SwiftUI and AppKit for a compact menu bar experience, not a browser wrapper. |
+| **Made to fit** | Choose what appears in the menu bar and which sections appear in the panel. |
 
-The universal app supports macOS 14 or later on both Apple Silicon and Intel Macs. The v0.1.5 download is signed with an Apple Development certificate but is not notarized. If macOS blocks the first launch, right-click `QuotaView.app` in Finder and choose **Open**.
+## Quick start
 
-## Features
+1. Make sure ChatGPT or Codex is installed and signed in.
+2. Download `QuotaView-v0.1.5.zip` from [GitHub Releases](https://github.com/Duoasa/QuotaView/releases/latest).
+3. Unzip it and open `QuotaView.app`.
 
-- Shows whether the current AI service is available, near its limit, or exhausted.
-- Displays the live subscription, weekly used quota, and remaining percentage.
-- Shows the countdown to the next quota reset.
-- Separates plan quota from additional Credits balance.
-- Presents available quota reset credits as a dedicated action.
-- Includes a quota reset detail view, risk acknowledgement, and final confirmation.
-- Keeps quota reset in demo mode without calling the real consume endpoint.
-- Uses a compact native status item and a dynamically sized custom menu panel.
-- Offers frosted and clear glass appearances with light/dark adaptation;
-  macOS 26 uses native Liquid Glass and macOS 14–15 retain a Material fallback.
-- Uses QuotaView's blue-violet visual identity throughout the interface.
-- Lets you choose which values appear in the menu bar and which of the six
-  content sections appear in the panel.
-- Includes a redesigned native Settings window with Menu Bar, Popover,
-  Appearance, Language, and General sections.
-- Uses the current macOS accent color for native settings controls.
-- Supports system-aware or fixed light/dark appearance.
-- Supports system-aware or fixed Simplified Chinese and English interfaces.
-- Displays recent daily and lifetime token usage.
-- Refreshes automatically every 60 seconds and supports manual refresh.
-- Locates Codex from ChatGPT, Homebrew, a custom path, or the current `PATH`.
-- Handles offline, missing installation, and App Server error states.
+> [!IMPORTANT]
+> The current v0.1.5 Build 6 is signed with an Apple Development certificate but is not notarized. If macOS blocks the first launch, right-click `QuotaView.app` in Finder and choose **Open**. Developer ID signing and notarization are on the roadmap.
 
-The first account request after launching from Finder may take 20–30 seconds. QuotaView allows a 45-second cold-start response window; later refreshes are usually much faster.
+The universal app supports macOS 14 or later on both Apple Silicon and Intel Macs. The first account request after launching from Finder may take 20–30 seconds; later refreshes are usually much faster.
 
-## Privacy
+## What it shows
 
-QuotaView stores only the latest successful refresh time, availability state, a short error summary, and your display preferences in its own macOS preferences domain. It does not store tokens or full account responses.
+- Current plan and service availability
+- Weekly used quota and remaining percentage
+- Countdown to the next quota reset
+- Plan quota and additional Credits as separate values
+- Available quota reset credits
+- Recent daily and lifetime token usage
+- Near-limit, exhausted, offline, and App Server error states
 
-For diagnostics:
+## Native experience
+
+- Compact status item with a dynamically sized menu panel
+- Automatic refresh every 60 seconds and manual refresh
+- Configurable menu bar values and six optional panel sections
+- Frosted and clear glass appearances with light/dark adaptation
+- Native Liquid Glass on macOS 26 and a Material fallback on macOS 14–15
+- System-aware or fixed light/dark appearance
+- English and Simplified Chinese interfaces
+- Native Settings window for Menu Bar, Popover, Appearance, Language, and General options
+
+## Privacy by design
+
+QuotaView does **not**:
+
+- scrape account web pages;
+- read, copy, or store login credentials from `~/.codex`;
+- store full account responses or authentication tokens.
+
+QuotaView starts the local `codex app-server` process and requests account data over JSON-RPC. It stores only the latest successful refresh time, availability state, a short error summary, and display preferences in its own macOS preferences domain.
+
+For local diagnostics:
 
 ```bash
 defaults read com.quotaview.menubar
 ```
 
+The app target disables App Sandbox because it must launch the locally installed `codex app-server`.
+
 ## Requirements
 
 - macOS 14 or later
-- Swift 6 or Xcode 16+
 - ChatGPT/Codex installed and signed in
+- Swift 6 or Xcode 16+ only when building from source
 
 QuotaView looks for the Codex executable in this order:
 
@@ -71,11 +104,20 @@ QuotaView looks for the Codex executable in this order:
 4. `/usr/local/bin/codex`
 5. The current `PATH`
 
-## Verify
+## Current limitations
 
-Run the unit tests:
+- Version 0.1.5 supports Codex only; more AI providers are planned.
+- The quota reset interface is a safety-focused demo and does not call `account/rateLimitResetCredit/consume`.
+- The App Server schema can vary with the installed Codex version.
+- The current downloadable build is not notarized.
+
+## Build and test
+
+Clone the repository and run the unit tests:
 
 ```bash
+git clone https://github.com/Duoasa/QuotaView.git
+cd QuotaView
 swift test
 ```
 
@@ -87,7 +129,13 @@ swift run QuotaViewProbe
 
 The probe prints the plan, quota percentages, reset time, Credits balance, and lifetime token usage. It never prints login credentials.
 
-## Build the App
+Run the app during development:
+
+```bash
+swift run QuotaView
+```
+
+Or create the Universal release app and ZIP:
 
 ```bash
 chmod +x scripts/build-app.sh
@@ -95,20 +143,7 @@ chmod +x scripts/build-app.sh
 open dist/QuotaView.app
 ```
 
-The build script creates a Universal Xcode Release build with the complete asset catalog:
-
-```text
-dist/QuotaView.app
-dist/QuotaView-v0.1.5.zip
-```
-
-Without additional options, the script prefers an installed Developer ID Application identity, then an Apple Development identity, and falls back to an ad-hoc signature with Hardened Runtime. To choose an identity explicitly:
-
-```bash
-CODESIGN_IDENTITY="Apple Development: Name (ID)" ./scripts/build-app.sh
-```
-
-For public distribution, use a Developer ID Application identity and an existing `notarytool` keychain profile:
+The build script prefers a Developer ID Application identity, then an Apple Development identity, and falls back to an ad-hoc signature with Hardened Runtime. For a notarized public build:
 
 ```bash
 CODESIGN_IDENTITY="Developer ID Application: Name (TEAMID)" \
@@ -116,33 +151,9 @@ NOTARY_PROFILE="QuotaView-notary" \
 ./scripts/build-app.sh
 ```
 
-The versioned ZIP preserves the signed macOS app bundle for GitHub Releases. Apple Development signatures are for development and testing; public distribution should use Developer ID signing and notarization.
+To use Xcode, open `QuotaView.xcodeproj`, select the shared **QuotaView** scheme and **My Mac**, then run or test.
 
-## Run During Development
-
-```bash
-swift run QuotaView
-```
-
-QuotaView appears only in the macOS menu bar and does not show a Dock icon.
-
-## Xcode
-
-Open the native Xcode project, select the shared `QuotaView` scheme and **My Mac**, then run or test:
-
-```bash
-open QuotaView.xcodeproj
-```
-
-The project contains three targets:
-
-- `QuotaView`: the menu bar app
-- `QuotaViewCore`: reusable account models and App Server communication
-- `QuotaViewTests`: core model and process communication tests
-
-The app target disables App Sandbox because it must launch the locally installed `codex app-server`. Select an Apple Developer Team in **Signing & Capabilities** before a signed production distribution.
-
-## Data Protocol
+## Data protocol
 
 After initialization, the client requests:
 
@@ -165,14 +176,12 @@ account/usage/read
 
 Credits and remaining plan quota are separate concepts and are never combined in the UI.
 
-Version 0.1.5 implements the quota reset interaction and safety confirmations but does not send `account/rateLimitResetCredit/consume`. A future implementation should add idempotency keys, explicit result handling, and protocol compatibility tests before enabling real quota resets.
-
-## Project Structure
+## Project structure
 
 ```text
 Sources/
 ├── QuotaView/              # SwiftUI views, settings, and AppKit menu panel
-├── QuotaViewCore/          # Provider client, executable locator, and models
+├── QuotaViewCore/          # Account models and App Server communication
 └── QuotaViewProbe/         # Read-only command-line probe
 Resources/
 ├── Assets.xcassets/        # App, menu bar, and interface artwork
@@ -183,11 +192,15 @@ Tests/
 
 ## Roadmap
 
-1. Add active task status and real-time notifications.
-2. Add launch-at-login with `ServiceManagement`.
-3. Add historical trends and quota alerts.
-4. Add a WidgetKit extension backed by an App Group.
-5. Add more AI providers.
-6. Add Developer ID signing, notarization, and automatic updates.
+- [ ] Active task status and real-time notifications
+- [ ] Launch at login with `ServiceManagement`
+- [ ] Historical trends and quota alerts
+- [ ] WidgetKit extension backed by an App Group
+- [ ] More AI providers
+- [ ] Developer ID signing, notarization, and automatic updates
 
-The App Server schema depends on the installed Codex version. Release CI should run `codex app-server generate-json-schema` and include protocol compatibility tests.
+## Feedback and contributions
+
+Bug reports, compatibility reports, and focused feature proposals are welcome. Start with the [issue templates](https://github.com/Duoasa/QuotaView/issues/new/choose), and read [CONTRIBUTING.md](CONTRIBUTING.md) before preparing a code change.
+
+Please never include authentication tokens, credentials, or an unredacted `~/.codex` file in an issue.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,64 +1,100 @@
-<img src="Resources/QuotaView-ICON.png" alt="QuotaView 图标" width="200">
+<p align="center">
+  <img src="Resources/QuotaView-ICON.png" alt="QuotaView 图标" width="160">
+</p>
 
-[English](README.md) | [**简体中文**](README.zh-CN.md)
+<h1 align="center">QuotaView</h1>
 
-# QuotaView
+<p align="center">
+  在 macOS 菜单栏直接查看 Codex 额度、Credits、Token 用量和重置时间。
+</p>
 
-QuotaView 是一款原生 macOS 菜单栏应用，用一个界面集中展示 AI 服务的额度、用量、余额和重置时间。0.1.5 版本首先支持读取本机已登录的 Codex 账户，后续计划适配更多 AI 服务。
+<p align="center">
+  <a href="https://github.com/Duoasa/QuotaView/releases/latest"><img alt="最新版本" src="https://img.shields.io/github/v/release/Duoasa/QuotaView?display_name=tag&sort=semver"></a>
+  <a href="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml"><img alt="CI 状态" src="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml/badge.svg"></a>
+  <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111?logo=apple">
+  <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white">
+</p>
 
-QuotaView 不会抓取网页，也不会读取、复制或保存 `~/.codex` 中的登录凭据。它会启动本地 `codex app-server` 进程，并通过其官方 JSON-RPC 接口读取账户数据。
+<p align="center">
+  <a href="https://github.com/Duoasa/QuotaView/releases/latest"><strong>下载最新版本</strong></a>
+  ·
+  <a href="#隐私设计">隐私说明</a>
+  ·
+  <a href="#构建与测试">从源码构建</a>
+</p>
 
-## 应用预览
+<p align="center">
+  <a href="README.md">English</a> · <strong>简体中文</strong>
+</p>
 
 ![QuotaView 应用预览](Resources/QuotaView-Preview.jpg)
 
-## 下载
+QuotaView 是一款专注于 Codex 的原生 macOS 菜单栏应用，使用本机已经登录的 Codex 账户。它让你在额度打断工作之前及时看到关键信息，不抓取网页，也不读取 `~/.codex` 中的登录凭据。
 
-前往 [GitHub Releases](https://github.com/Duoasa/QuotaView/releases) 下载 `QuotaView-v0.1.5.zip`，解压后打开 `QuotaView.app`。
+## 为什么选择 QuotaView
 
-当前提供的是 v0.1.5 Build 6 热更新，修复了可用状态标签的背景形状和颜色向外晕染问题。
+| | |
+| --- | --- |
+| **一眼掌握** | 无需离开当前应用，即可查看已用与剩余额度、重置倒计时、Credits 和可用状态。 |
+| **本地连接** | 通过 JSON-RPC 与本机启动的 `codex app-server` 进程通信。 |
+| **原生 macOS** | 使用 SwiftUI 和 AppKit 构建紧凑的菜单栏体验，不是网页套壳。 |
+| **按需显示** | 可以选择菜单栏显示的数值，以及面板中需要出现的内容区域。 |
 
-Universal 应用支持 macOS 14 或更高版本，同时兼容 Apple 芯片和 Intel Mac。v0.1.5 使用 Apple Development 证书签名，但尚未完成公证。如果 macOS 首次启动时拦截应用，请在 Finder 中右键点击 `QuotaView.app`，然后选择**打开**。
+## 快速开始
 
-## 功能
+1. 确认已经安装并登录 ChatGPT 或 Codex。
+2. 前往 [GitHub Releases](https://github.com/Duoasa/QuotaView/releases/latest) 下载 `QuotaView-v0.1.5.zip`。
+3. 解压后打开 `QuotaView.app`。
 
-- 显示当前 AI 服务是否可用、接近额度上限或额度已用尽。
-- 显示当前订阅、本周已用额度和剩余百分比。
-- 显示距离下次额度重置的倒计时。
-- 分别展示套餐额度和额外 Credits 余额。
-- 将可用的额度重置次数显示为独立操作。
-- 提供额度重置详情、风险确认和最终确认流程。
-- 额度重置保持演示模式，不会调用真实的消费接口。
-- 使用紧凑的原生状态栏入口和可随内容动态调整高度的自定义面板。
-- 提供磨砂和清透两种玻璃效果，并自动适配浅色与深色模式；macOS 26 使用原生 Liquid Glass，macOS 14–15 使用 Material 兼容方案。
-- 在整个界面中使用 QuotaView 的蓝紫色视觉风格。
-- 可自定义菜单栏内容，以及面板中六个内容区域的显示状态。
-- 提供重新设计的原生设置窗口，包含菜单栏、面板内容、外观、语言和通用五个页面。
-- 原生设置控件会跟随当前 macOS 系统强调色。
-- 支持跟随系统或固定使用浅色、深色外观。
-- 支持跟随系统或固定使用简体中文、英文界面。
-- 显示近期每日和累计 Token 用量。
-- 每 60 秒自动刷新，也支持手动刷新。
-- 可从 ChatGPT、Homebrew、自定义路径或当前 `PATH` 中查找 Codex。
-- 妥善处理离线、未安装和 App Server 错误状态。
+> [!IMPORTANT]
+> 当前 v0.1.5 Build 6 使用 Apple Development 证书签名，但尚未完成公证。如果 macOS 首次启动时拦截应用，请在 Finder 中右键点击 `QuotaView.app`，然后选择**打开**。Developer ID 签名与公证已列入路线图。
 
-从 Finder 启动后的首次账户请求可能需要 20–30 秒。QuotaView 为冷启动预留了 45 秒响应时间，后续刷新通常会快很多。
+Universal 应用支持 macOS 14 或更高版本，同时兼容 Apple 芯片和 Intel Mac。从 Finder 启动后的首次账户请求可能需要 20–30 秒，后续刷新通常会快很多。
 
-## 隐私
+## 展示的数据
 
-QuotaView 只会在自己的 macOS 偏好设置域中保存最近一次成功刷新时间、可用状态、简短错误摘要和显示偏好。它不会保存 Token 或完整的账户响应。
+- 当前套餐和服务可用状态
+- 本周已用额度和剩余百分比
+- 距离下次额度重置的倒计时
+- 分别展示套餐额度和额外 Credits
+- 可用的额度重置次数
+- 近期每日和累计 Token 用量
+- 接近上限、额度耗尽、离线和 App Server 错误状态
 
-诊断偏好设置：
+## 原生使用体验
+
+- 紧凑的状态栏入口和可动态调整高度的菜单面板
+- 每 60 秒自动刷新，同时支持手动刷新
+- 可配置菜单栏数值和六个面板内容区域
+- 提供磨砂和清透玻璃效果，并适配浅色与深色模式
+- macOS 26 使用原生 Liquid Glass，macOS 14–15 使用 Material 兼容方案
+- 支持跟随系统或固定使用浅色、深色外观
+- 支持简体中文和英文界面
+- 原生设置窗口包含菜单栏、面板内容、外观、语言和通用选项
+
+## 隐私设计
+
+QuotaView **不会**：
+
+- 抓取账户网页；
+- 读取、复制或保存 `~/.codex` 中的登录凭据；
+- 保存完整账户响应或身份认证 Token。
+
+QuotaView 会启动本地 `codex app-server` 进程，并通过 JSON-RPC 请求账户数据。它只会在自己的 macOS 偏好设置域中保存最近一次成功刷新时间、可用状态、简短错误摘要和显示偏好。
+
+本地诊断命令：
 
 ```bash
 defaults read com.quotaview.menubar
 ```
 
+应用 Target 已关闭 App Sandbox，因为它需要启动本机安装的 `codex app-server`。
+
 ## 系统要求
 
 - macOS 14 或更高版本
-- Swift 6 或 Xcode 16+
 - 已安装并登录 ChatGPT/Codex
+- 仅在从源码构建时需要 Swift 6 或 Xcode 16+
 
 QuotaView 会按以下顺序查找 Codex 可执行文件：
 
@@ -68,11 +104,20 @@ QuotaView 会按以下顺序查找 Codex 可执行文件：
 4. `/usr/local/bin/codex`
 5. 当前 `PATH`
 
-## 验证
+## 当前限制
 
-运行单元测试：
+- 0.1.5 版本仅支持 Codex，后续计划适配更多 AI 服务。
+- 额度重置界面仍是安全演示，不会调用 `account/rateLimitResetCredit/consume`。
+- App Server Schema 可能随本机安装的 Codex 版本变化。
+- 当前提供下载的构建尚未完成公证。
+
+## 构建与测试
+
+克隆仓库并运行单元测试：
 
 ```bash
+git clone https://github.com/Duoasa/QuotaView.git
+cd QuotaView
 swift test
 ```
 
@@ -84,7 +129,13 @@ swift run QuotaViewProbe
 
 探针会输出套餐、额度百分比、重置时间、Credits 余额和累计 Token 用量，不会输出登录凭据。
 
-## 构建应用
+在开发环境中运行应用：
+
+```bash
+swift run QuotaView
+```
+
+或者创建 Universal Release 应用和 ZIP：
 
 ```bash
 chmod +x scripts/build-app.sh
@@ -92,20 +143,7 @@ chmod +x scripts/build-app.sh
 open dist/QuotaView.app
 ```
 
-构建脚本会创建包含完整资源目录的 Universal Xcode Release 构建：
-
-```text
-dist/QuotaView.app
-dist/QuotaView-v0.1.5.zip
-```
-
-在没有额外参数时，脚本会优先使用已安装的 Developer ID Application 身份，其次使用 Apple Development 身份，最后使用带 Hardened Runtime 的 ad-hoc 签名。若要明确指定签名身份：
-
-```bash
-CODESIGN_IDENTITY="Apple Development: Name (ID)" ./scripts/build-app.sh
-```
-
-公开分发时，请使用 Developer ID Application 身份和已有的 `notarytool` 钥匙串配置：
+构建脚本会优先使用 Developer ID Application 身份，其次使用 Apple Development 身份，最后使用带 Hardened Runtime 的 ad-hoc 签名。创建经过公证的公开构建：
 
 ```bash
 CODESIGN_IDENTITY="Developer ID Application: Name (TEAMID)" \
@@ -113,31 +151,7 @@ NOTARY_PROFILE="QuotaView-notary" \
 ./scripts/build-app.sh
 ```
 
-带版本号的 ZIP 会保留已签名的 macOS 应用包，可直接用于 GitHub Releases。Apple Development 签名仅适合开发和测试；公开分发应使用 Developer ID 签名和 Apple 公证。
-
-## 开发运行
-
-```bash
-swift run QuotaView
-```
-
-QuotaView 只会出现在 macOS 菜单栏中，不会显示 Dock 图标。
-
-## Xcode
-
-打开原生 Xcode 项目，选择共享的 `QuotaView` Scheme 和 **My Mac**，然后运行或测试：
-
-```bash
-open QuotaView.xcodeproj
-```
-
-项目包含三个 Target：
-
-- `QuotaView`：菜单栏应用
-- `QuotaViewCore`：可复用的账户模型和 App Server 通信层
-- `QuotaViewTests`：核心模型与进程通信测试
-
-应用 Target 已关闭 App Sandbox，因为它需要启动本机安装的 `codex app-server`。创建正式签名版本前，请在 **Signing & Capabilities** 中选择 Apple Developer Team。
+使用 Xcode 时，请打开 `QuotaView.xcodeproj`，选择共享的 **QuotaView** Scheme 和 **My Mac**，然后运行或测试。
 
 ## 数据协议
 
@@ -162,29 +176,31 @@ account/usage/read
 
 Credits 与套餐剩余额度是两个独立概念，界面不会将它们合并。
 
-0.1.5 版本已经实现额度重置交互和安全确认，但不会发送 `account/rateLimitResetCredit/consume` 请求。未来启用真实额度重置前，应加入幂等键、明确的结果处理和协议兼容性测试。
-
 ## 项目结构
 
 ```text
 Sources/
 ├── QuotaView/              # SwiftUI 界面、设置与 AppKit 菜单面板
-├── QuotaViewCore/          # 服务客户端、可执行文件查找与数据模型
+├── QuotaViewCore/          # 账户模型和 App Server 通信层
 └── QuotaViewProbe/         # 只读命令行探针
 Resources/
-├── Assets.xcassets/        # App、菜单栏与界面资源
+├── Assets.xcassets/        # 应用、菜单栏和界面资源
 └── Fonts/                  # 内置 Asta Sans 字体文件
 Tests/
-└── QuotaViewCoreTests/     # 模型映射与进程通信测试
+└── QuotaViewCoreTests/     # 模型映射和进程通信测试
 ```
 
 ## 路线图
 
-1. 添加活跃任务状态和实时通知。
-2. 使用 `ServiceManagement` 添加开机启动。
-3. 添加历史趋势和额度提醒。
-4. 添加基于 App Group 的 WidgetKit 扩展。
-5. 适配更多 AI 服务。
-6. 添加 Developer ID 签名、公证和自动更新。
+- [ ] 活跃任务状态和实时通知
+- [ ] 使用 `ServiceManagement` 实现登录时启动
+- [ ] 历史趋势和额度提醒
+- [ ] 基于 App Group 的 WidgetKit 扩展
+- [ ] 适配更多 AI 服务
+- [ ] Developer ID 签名、公证和自动更新
 
-App Server Schema 取决于本机安装的 Codex 版本。Release CI 应运行 `codex app-server generate-json-schema` 并包含协议兼容性测试。
+## 反馈与贡献
+
+欢迎提交 Bug、兼容性报告和目标明确的功能建议。请先使用 [Issue 模板](https://github.com/Duoasa/QuotaView/issues/new/choose)，准备代码改动前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+请勿在 Issue 中包含身份认证 Token、登录凭据或未经脱敏的 `~/.codex` 文件。


### PR DESCRIPTION
## What changed

- reorganizes the English and Simplified Chinese READMEs around a clear product promise, download path, privacy model, requirements, limitations, and roadmap
- adds release, platform, Swift, and CI badges
- adds a macOS Swift test workflow
- adds structured bug and feature request forms plus a pull request template
- adds contributor guidance with Codex compatibility and credential-safety expectations

## Why

The previous README was thorough but presented the repository more like a technical manual than a product page. This change makes the first screen easier to understand for prospective users while keeping the protocol, build, and privacy details available to developers.

## User and developer impact

Users get a shorter path from discovery to download and clearer disclosure about signing, notarization, supported platforms, and the demo-only reset flow. Contributors get repeatable tests and structured ways to report issues without exposing account credentials.

## Validation

- `swift test` — 4 tests passed
- `git diff --check`
- parsed every `.github/**/*.yml` file successfully
- verified local Markdown file links

## Notes

- no application source code changed
- no license was added because that choice should be made separately by the repository owner
- GitHub-rendered visual review remains pending after the PR is available
