### PR TITLE
Harden release artifact verification

### DIFF
--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -210,6 +210,7 @@ fi
 mv "${staging_app}" "${destination_app}"
 mv -f "${staging_zip}" "${destination_zip}"
 
+xattr -cr "${destination_app}"
 codesign \
     --verify \
     --deep \


### PR DESCRIPTION
## Summary

- clear macOS Finder metadata after moving the signed app into `dist`
- keep strict post-move signature verification enabled

## Verification

- Universal Release build succeeded
- `dist/QuotaView.app` passed deep strict code-signature verification
- ZIP extraction verification and pre/post-move SHA-256 comparison passed
