### PR TITLE
Mark v0.2.0 as an official release

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -267,9 +267,8 @@ NOTARY_PROFILE="<keychain-profile>" \
 ```
 
 Apple Developer 账号仍在审批时，不得把 Apple Development 或 ad-hoc
-签名描述成可公开分发的 Developer ID 签名。若审批前必须发布测试版，
-应标记为 GitHub Pre-release，并在 Release Notes 中明确说明未公证及
-Gatekeeper 限制。
+签名描述成 Developer ID 签名。若在审批前发布正式版本，Release Notes
+必须明确说明实际签名方式、未公证状态及 Gatekeeper 限制。
 
 脚本成功后预期生成：
 
@@ -338,8 +337,8 @@ xcrun stapler validate \
    `v0.2.0`；
 2. 等待收口提交进入远程 `main` 且 CI 通过，记录最终 commit SHA；
 3. 从这个最终 commit 构建正式包，不使用其他工作区状态；
-4. 正式版完成 Developer ID 签名、公证和 Staple；审批前发布的
-   Pre-release 使用 ad-hoc Hardened Runtime 并完成 ZIP 解包验签；
+4. 正式版优先完成 Developer ID 签名、公证和 Staple；审批前发布的
+   v0.2.0 正式版使用 ad-hoc Hardened Runtime 并完成 ZIP 解包验签；
 5. 产品所有者运行最终解包 App，完成发布候选验收；
 6. 计算最终 ZIP SHA-256；
 7. 在同一个最终 commit 创建 annotated tag `v0.2.0`；
@@ -390,7 +389,8 @@ SHA-256:
 ```
 
 如果正式包尚未完成 Developer ID 公证，必须在正文开头增加醒目的
-“Pre-release / Not notarized”说明，不得使用暗示已通过 Gatekeeper 的表述。
+“Not notarized / ad-hoc signature”说明，不得使用暗示已通过 Gatekeeper
+的表述。
 
 ## 11. 当前 Git 工作区
 
@@ -402,7 +402,7 @@ SHA-256:
   `subtract-frosted-glass-icon-transparent.png` 未跟踪且未被代码引用；
 - `docs/reference/` 保持未跟踪，不属于本次发布范围；
 - `dist/` 已生成 ad-hoc Hardened Runtime 签名、未公证的
-  `QuotaView-v0.2.0.zip` Pre-release 候选；
+  `QuotaView-v0.2.0.zip` 正式发行候选；
 - 视觉与交互状态仍为“等待用户验收”。
 
 在明确提交范围前，不要执行 reset、checkout、clean、删除文件或覆盖

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Duoasa/QuotaView/releases/tag/v0.2.0"><img alt="Latest release" src="https://img.shields.io/badge/release-v0.2.0--pre--release-orange"></a>
+  <a href="https://github.com/Duoasa/QuotaView/releases/tag/v0.2.0"><img alt="Latest release" src="https://img.shields.io/github/v/release/Duoasa/QuotaView?display_name=tag&sort=semver"></a>
   <a href="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111?logo=apple">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white">
@@ -48,10 +48,10 @@ QuotaView is a simple, lightweight, native macOS menu bar app for the Codex acco
 3. Unzip it and open `QuotaView.app`.
 
 > [!IMPORTANT]
-> v0.2.0 Build 1 is a pre-release with an ad-hoc Hardened Runtime signature
-> and is not notarized. If macOS blocks the first launch, right-click
-> `QuotaView.app` in Finder and choose **Open**. Developer ID signing and
-> notarization are on the roadmap.
+> v0.2.0 Build 1 is the first official release built on QuotaView's refactored
+> core. It uses an ad-hoc Hardened Runtime signature and is not notarized. If
+> macOS blocks the first launch, right-click `QuotaView.app` in Finder and
+> choose **Open**. Developer ID signing and notarization are on the roadmap.
 
 The universal app supports macOS 14 or later on both Apple Silicon and Intel Macs. The first account request after launching from Finder may take 20–30 seconds; later refreshes are usually much faster.
 
@@ -77,6 +77,8 @@ The universal app supports macOS 14 or later on both Apple Silicon and Intel Mac
 - Native Settings window for Menu Bar, Popover, Appearance, Language, and General options
 
 ## What's new in 0.2.0
+
+v0.2.0 is the first official release built on QuotaView's refactored core.
 
 - A normalized domain and static provider registry prepare QuotaView for more
   official AI data sources without adding a plugin runtime.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Duoasa/QuotaView/releases/tag/v0.2.0"><img alt="最新版本" src="https://img.shields.io/badge/release-v0.2.0--pre--release-orange"></a>
+  <a href="https://github.com/Duoasa/QuotaView/releases/tag/v0.2.0"><img alt="最新版本" src="https://img.shields.io/github/v/release/Duoasa/QuotaView?display_name=tag&sort=semver"></a>
   <a href="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml"><img alt="CI 状态" src="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111?logo=apple">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white">
@@ -48,9 +48,10 @@ QuotaView 是一款简洁、轻量的原生 macOS 菜单栏应用，使用本机
 3. 解压后打开 `QuotaView.app`。
 
 > [!IMPORTANT]
-> v0.2.0 Build 1 是使用 ad-hoc Hardened Runtime 签名、尚未完成公证的
-> Pre-release。如果 macOS 首次启动时拦截应用，请在 Finder 中右键点击
-> `QuotaView.app`，然后选择**打开**。Developer ID 签名与公证已列入路线图。
+> v0.2.0 Build 1 是 QuotaView 完成核心重构后的首个正式发行版。当前构建
+> 使用 ad-hoc Hardened Runtime 签名，尚未完成公证。如果 macOS 首次启动
+> 时拦截应用，请在 Finder 中右键点击 `QuotaView.app`，然后选择**打开**。
+> Developer ID 签名与公证已列入路线图。
 
 Universal 应用支持 macOS 14 或更高版本，同时兼容 Apple 芯片和 Intel Mac。从 Finder 启动后的首次账户请求可能需要 20–30 秒，后续刷新通常会快很多。
 
@@ -76,6 +77,8 @@ Universal 应用支持 macOS 14 或更高版本，同时兼容 Apple 芯片和 I
 - 原生设置窗口包含菜单栏、面板内容、外观、语言和通用选项
 
 ## 0.2.0 更新内容
+
+v0.2.0 是 QuotaView 完成核心重构后的首个正式发行版。
 
 - 引入标准化 Domain 与静态 Provider Registry，为接入更多官方 AI 数据源
   做好准备，同时不增加动态插件运行层。


### PR DESCRIPTION
## Summary

- identify v0.2.0 Build 1 as the first official release after the core refactor
- replace the pre-release badge and wording in both READMEs
- retain the accurate ad-hoc signature, not-notarized, and Gatekeeper warnings
- align the handoff release guidance with the official-release decision

## Impact

This is a documentation and release-classification correction. The v0.2.0 app
binary and downloadable ZIP are unchanged.

## Verification

- bilingual wording reviewed for matching meaning
- Markdown diff check passed
- unrelated untracked assets remain excluded
