### PR TITLE
Record QuotaView 0.3.1 Build 2 release

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -7,7 +7,7 @@
 当前生产分支：`main`
 
 当前发布提交与生产基线：
-`041c698ae9755d458fa9f111e4ac74e9711048b9`
+`3119171f45163fe45d68a4f774a0488968f14fd7`
 
 远程：`https://github.com/Duoasa/QuotaView.git`
 
@@ -21,48 +21,48 @@
 
 | 项目 | 当前值 |
 |---|---|
-| 最新推荐版本 | `0.3.1 (Build 1)` |
-| tag | `v0.3.1` |
-| 发布提交 | `041c698ae9755d458fa9f111e4ac74e9711048b9` |
-| Release | [QuotaView 0.3.1 — Codex Island](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.1) |
-| 资产 | `QuotaView-v0.3.1.zip` |
-| SHA-256 | `ff2417f40c8d5ad9e12c4c3c42101fb3e12e9e04c137c1bc6a42e2b56bf50e2d` |
+| 最新推荐版本 | `0.3.1 (Build 2)` |
+| tag | `v0.3.1-build.2` |
+| 发布提交 | `3119171f45163fe45d68a4f774a0488968f14fd7` |
+| Release | [QuotaView 0.3.1 Build 2 — Widget Hotfix](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.1-build.2) |
+| 资产 | `QuotaView-v0.3.1-build.2.zip` |
+| SHA-256 | `9051b60799a5a20e578c2eea4e3f3a5b3725109b553fc8580473953c0f59a1ed` |
 
-`0.3.1 (Build 1)` 已完成 Developer ID 签名、Apple 公证、Staple、
+`0.3.1 (Build 2)` 已完成 Developer ID 签名、Apple 公证、Staple、
 GitHub Release、Latest 切换和 GitHub 回下载复核，是当前公开生产基线。
 
-2026-08-01：本地 `0.3.1 (Build 2)` Widget 热修复候选已完成实现与
-安装验证。macOS
-系统日志确认，公开 Build 1 的 Widget 在 Developer ID 直接分发环境中被
+2026-08-01：`0.3.1 (Build 2)` Widget 热修复已正式发布。macOS 系统日志
+确认，公开 Build 1 的 Widget 在 Developer ID 直接分发环境中被
 `SystemPolicyAppData` 拒绝读取 `group.com.quotaview.shared`。Build 2 将
 App Group 迁移为团队前缀 `BUUH229D5Q.com.quotaview.shared`，符合未嵌入
 provisioning profile 的公证 App 共享容器要求。`swift test` 共 `53` 项
 通过，Universal Release 构建和 Developer ID 签名验证通过；App、Widget
 与 Helper 均为 `x86_64 arm64`。安装后新容器写入有效快照，Widget 时间线
 成功归档，内核不再出现共享快照读取拒绝；视觉结果等待产品所有者验收。
-正式发布资产已完成 Apple 公证和 Staple，但尚未上传 GitHub，不得提前
-改写 GitHub Latest、tag、Release URL 或公开资产记录。
+正式发布资产已完成 Apple 公证、Staple、GitHub 上传、回下载逐字节比对、
+Gatekeeper 和真实启动复核。
 
 Build 2 将主面板与 Widget 的额度标题从“本周剩余”统一调整为“本周期
 剩余”，英文使用两词 `Period Remaining`，以兼容 Codex 的 5 小时、7 天
 及后续可变用量周期；Tooltip、VoiceOver 与实现内部命名同步使用周期语义。
 
-### 0.3.1 Build 2 GitHub 发布候选
+## 1. 0.3.1 Build 2 正式发布状态
 
-目标发布元数据：
+正式发布元数据：
 
-| 项目 | 候选值 |
+| 项目 | 发布值 |
 |---|---|
 | Marketing Version | `0.3.1` |
 | Build Number | `2` |
-| 建议 tag | `v0.3.1-build.2` |
-| 建议 Release 标题 | `QuotaView 0.3.1 Build 2 — Widget Hotfix` |
+| tag | `v0.3.1-build.2` |
+| Release 标题 | `QuotaView 0.3.1 Build 2 — Widget Hotfix` |
+| 发布提交 | `3119171f45163fe45d68a4f774a0488968f14fd7` |
 | 最终资产名 | `QuotaView-v0.3.1-build.2.zip` |
 | App Group | `BUUH229D5Q.com.quotaview.shared` |
 | 最低系统版本 | macOS 14 |
 | 架构 | Universal `arm64 + x86_64` |
 
-本地正式发布资产（尚未上传 GitHub）：
+正式 GitHub Release 资产：
 
 | 项目 | 当前值 |
 |---|---|
@@ -117,10 +117,10 @@ Build 2 发布检查清单：
 - [x] 对最终 ZIP 全新解压并执行 `codesign`、`stapler`、`spctl`、版本、
   架构、资源、隔离属性和真实启动烟雾测试；
 - [x] 将最终资产大小、SHA-256 和 Submission ID 同步到本文件；发布提交、
-  `VERSION_HISTORY.md` 与 README 中英文版本待 Release 建立后同步；
-- [ ] 创建发布提交，使用唯一 tag `v0.3.1-build.2`，上传唯一正式 ZIP，
+  `VERSION_HISTORY.md` 与 README 中英文版本已同步；
+- [x] 创建发布提交，使用唯一 tag `v0.3.1-build.2`，上传唯一正式 ZIP，
   将 GitHub Latest 切换到 Build 2；
-- [ ] 从 GitHub 回下载资产，逐字节核对并再次验签和启动测试。
+- [x] 从 GitHub 回下载资产，逐字节核对并再次验签和启动测试。
 
 2026-08-01：宣传片摄录专用的本地 `0.3.2 Demo` 已结束使用；灵动岛已
 恢复为完成后 `20` 秒紧凑、
@@ -136,7 +136,7 @@ Widget 与 Helper 均包含 `x86_64 arm64`。视觉与实机时序等待产品�
 - `AGENTS.md`：长期产品、设计、实现和发布约束；
 - `design-qa.md`：视觉验收历史。
 
-## 1. 0.3.1 正式发布状态
+## 1.1 0.3.1 Build 1 历史发布状态
 
 ### 版本定位
 
@@ -145,8 +145,8 @@ Widget 与 Helper 均包含 `x86_64 arm64`。视觉与实机时序等待产品�
 | Marketing Version | `0.3.1` |
 | Build Number | `1` |
 | 开发主题 | Codex 灵动岛正式接入 |
-| 发布状态 | 正式 Release、Latest、非 Draft、非 Pre-release |
-| 公开 Latest | `0.3.1 (Build 1)` |
+| 发布状态 | 历史正式 Release，已由 Build 2 取代 |
+| 公开 Latest | `0.3.1 (Build 2)` |
 
 ### 已实现
 

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Duoasa/QuotaView/releases/tag/v0.3.1"><img alt="Latest release" src="https://img.shields.io/github/v/release/Duoasa/QuotaView?display_name=tag&sort=semver"></a>
+  <a href="https://github.com/Duoasa/QuotaView/releases/tag/v0.3.1-build.2"><img alt="Latest release" src="https://img.shields.io/github/v/release/Duoasa/QuotaView?display_name=tag"></a>
   <a href="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111?logo=apple">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white">
 </p>
 
 <p align="center">
-  <a href="https://github.com/Duoasa/QuotaView/releases/download/v0.3.1/QuotaView-v0.3.1.zip"><strong>Download QuotaView v0.3.1</strong></a>
+  <a href="https://github.com/Duoasa/QuotaView/releases/download/v0.3.1-build.2/QuotaView-v0.3.1-build.2.zip"><strong>Download QuotaView v0.3.1 Build 2</strong></a>
   ·
   <a href="#privacy-by-design">Privacy</a>
   ·
@@ -48,11 +48,11 @@ QuotaView is a simple, lightweight, native macOS companion for the Codex account
 ## Quick start
 
 1. Make sure ChatGPT or Codex is installed and signed in.
-2. Download `QuotaView-v0.3.1.zip` from the [v0.3.1 release](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.1).
+2. Download `QuotaView-v0.3.1-build.2.zip` from the [v0.3.1 Build 2 release](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.1-build.2).
 3. Unzip it and open `QuotaView.app`.
 
 > [!IMPORTANT]
-> v0.3.1 is signed with a Developer ID certificate, notarized by Apple, and
+> v0.3.1 Build 2 is signed with a Developer ID certificate, notarized by Apple, and
 > stapled for offline Gatekeeper verification. It can be opened normally after
 > unzipping, without using the Finder right-click workaround required by older
 > unsigned builds.
@@ -82,6 +82,15 @@ The universal app supports macOS 14 or later on both Apple Silicon and Intel Mac
 - English and Simplified Chinese interfaces
 - Native Settings window for Menu Bar, Popover, Appearance, Language, and General options
 - Native WidgetKit widgets in Small and Medium sizes
+
+## 0.3.1 Build 2 widget hotfix
+
+- Restores Small and Medium widget data in notarized direct downloads by using
+  the team-prefixed shared App Group required by macOS.
+- Renames “Weekly Remaining” to “Period Remaining” across the app, widgets,
+  tooltips, and accessibility copy to support variable Codex quota periods.
+- Adds a release packaging check that prevents an incompatible App Group from
+  reaching a notarized direct-distribution build.
 
 ## What's new in 0.3.1: Codex Island
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,14 +9,14 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Duoasa/QuotaView/releases/tag/v0.3.1"><img alt="最新版本" src="https://img.shields.io/github/v/release/Duoasa/QuotaView?display_name=tag&sort=semver"></a>
+  <a href="https://github.com/Duoasa/QuotaView/releases/tag/v0.3.1-build.2"><img alt="最新版本" src="https://img.shields.io/github/v/release/Duoasa/QuotaView?display_name=tag"></a>
   <a href="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml"><img alt="CI 状态" src="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111?logo=apple">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white">
 </p>
 
 <p align="center">
-  <a href="https://github.com/Duoasa/QuotaView/releases/download/v0.3.1/QuotaView-v0.3.1.zip"><strong>下载 QuotaView v0.3.1</strong></a>
+  <a href="https://github.com/Duoasa/QuotaView/releases/download/v0.3.1-build.2/QuotaView-v0.3.1-build.2.zip"><strong>下载 QuotaView v0.3.1 Build 2</strong></a>
   ·
   <a href="#隐私设计">隐私说明</a>
   ·
@@ -48,11 +48,11 @@ QuotaView 是一款简洁、轻量的原生 macOS Codex 助手，使用本机已
 ## 快速开始
 
 1. 确认已经安装并登录 ChatGPT 或 Codex。
-2. 前往 [v0.3.1 Release](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.1) 下载 `QuotaView-v0.3.1.zip`。
+2. 前往 [v0.3.1 Build 2 Release](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.1-build.2) 下载 `QuotaView-v0.3.1-build.2.zip`。
 3. 解压后打开 `QuotaView.app`。
 
 > [!IMPORTANT]
-> v0.3.1 已使用 Developer ID 证书签名、通过 Apple 公证并完成 Staple，
+> v0.3.1 Build 2 已使用 Developer ID 证书签名、通过 Apple 公证并完成 Staple，
 > 可在解压后正常打开，不再需要旧版未签名构建所使用的 Finder 右键打开
 > 方式。
 
@@ -81,6 +81,14 @@ Universal 应用支持 macOS 14 或更高版本，同时兼容 Apple 芯片和 I
 - 支持简体中文和英文界面
 - 原生设置窗口包含菜单栏、面板内容、外观、语言和通用选项
 - 提供小号与中号两种原生 WidgetKit 小组件
+
+## 0.3.1 Build 2 小组件热修复
+
+- 使用 macOS 直接分发所需的团队前缀共享 App Group，恢复已公证下载版的
+  小号与中号 Widget 数据。
+- 将 App、小组件、Tooltip 和辅助功能文案中的“本周剩余”统一改为“本周期
+  剩余”，兼容 Codex 的可变额度周期。
+- 新增发布打包门禁，避免不兼容的 App Group 配置进入公证分发包。
 
 ## 0.3.1 最大更新：Codex 灵动岛
 

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -14,30 +14,22 @@
 
 | 项目 | 当前值 |
 |---|---|
-| 最新推荐版本 | `0.3.1 (Build 1)` |
-| Git tag | `v0.3.1` |
-| Tag commit | `041c698ae9755d458fa9f111e4ac74e9711048b9` |
-| GitHub Release | [QuotaView 0.3.1 — Codex Island](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.1) |
-| Release 资产 | `QuotaView-v0.3.1.zip` |
-| 资产大小 | `11,443,295 bytes` |
-| SHA-256 | `ff2417f40c8d5ad9e12c4c3c42101fb3e12e9e04c137c1bc6a42e2b56bf50e2d` |
+| 最新推荐版本 | `0.3.1 (Build 2)` |
+| Git tag | `v0.3.1-build.2` |
+| Tag commit | `3119171f45163fe45d68a4f774a0488968f14fd7` |
+| GitHub Release | [QuotaView 0.3.1 Build 2 — Widget Hotfix](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.1-build.2) |
+| Release 资产 | `QuotaView-v0.3.1-build.2.zip` |
+| 资产大小 | `11,443,325 bytes` |
+| SHA-256 | `9051b60799a5a20e578c2eea4e3f3a5b3725109b553fc8580473953c0f59a1ed` |
 | 最低系统版本 | macOS 14 |
 | 架构 | Universal `arm64 + x86_64` |
 | 签名 | `Developer ID Application: Chenchen Xu (BUUH229D5Q)`，启用 Hardened Runtime |
-| 公证 | Apple Accepted，已 Staple；Submission `2b125886-a3dc-4734-a139-280a08302e5c` |
+| 公证 | Apple Accepted，已 Staple；Submission `0ff9bf81-3570-4243-b3be-5d076b0f888c` |
 | 发布状态 | 正式 Release、Latest、非 Draft、非 Pre-release |
 
-> 当前生产版本为 `0.3.1 (Build 1)`，核心定位为 Codex 灵动岛。开发、
-> 验证与发布记录见
-> [HANDOFF.md](HANDOFF.md#1-031-正式发布状态)。
-
-> 2026-08-01 已确认公开 Build 1 的 Widget 在 Developer ID 直接分发环境
-> 中会被 `SystemPolicyAppData` 拒绝读取未带团队前缀的 App Group，导致小号
-> 与中号小组件显示“额度数据不可用”。本地 `0.3.1 (Build 2)` 热修复候选
-> 已迁移到 `BUUH229D5Q.com.quotaview.shared`，并将当前额度标题统一为
-> “本周期剩余” / `Period Remaining`。在 Build 2 完成公证并创建独立
-> Release 前，本节继续保留已经发生的 Build 1 公开发布事实；候选元数据、
-> 验证结果和发布清单见 [HANDOFF.md](HANDOFF.md#031-build-2-github-发布候选)。
+> 当前生产版本为 `0.3.1 (Build 2)`。该热修复保留 Codex 灵动岛，并恢复
+> Developer ID 直接分发环境中的 Widget 数据共享。开发、验证与发布记录见
+> [HANDOFF.md](HANDOFF.md#1-031-build-2-正式发布状态)。
 
 ### 版本定位规则
 
@@ -54,7 +46,8 @@
 
 | 版本 | 日期（Asia/Shanghai） | 状态 | 核心定位 |
 |---|---|---|---|
-| `0.3.1 (Build 1)` | 2026-07-30 | **当前最新** | Codex 灵动岛实时任务状态与官方 Hooks 连接 |
+| `0.3.1 (Build 2)` | 2026-08-01 | **当前最新** | Widget 共享容器热修复与可变额度周期文案 |
+| `0.3.1 (Build 1)` | 2026-07-30 | 历史正式版 | Codex 灵动岛实时任务状态与官方 Hooks 连接 |
 | `0.2.1 (Build 1)` | 2026-07-30 | 历史正式版 | 原生 WidgetKit 小组件与 Developer ID 公证分发 |
 | `0.2.0 (Build 4)` | 2026-07-29 | 历史正式版 | UI 热更新与下载版启动可靠性修复 |
 | `0.2.0 (Build 3)` | 2026-07-29 | **已撤回并删除** | UI1/UI2 组件细节迭代；发布包存在 Framework 加载故障 |
@@ -63,11 +56,49 @@
 | `0.1.3` | 2026-07-26 | 历史正式版 | 设置、外观、语言、图标和发布流程完善 |
 | `0.1.0` | 2026-07-26 | 首个公开版本 | Codex 额度、Credits、Token 与重置时间基础能力 |
 
+## 0.3.1 (Build 2)
+
+Tag：`v0.3.1-build.2`
+
+状态：当前最新正式 Release、GitHub Latest、非 Draft、非 Pre-release。
+
+发布提交：
+`3119171f45163fe45d68a4f774a0488968f14fd7`
+
+主要变更：
+
+- 将 App 与 Widget Extension 的共享容器迁移为团队前缀 App Group
+  `BUUH229D5Q.com.quotaview.shared`，恢复 Developer ID 公证下载版的小号
+  与中号 Widget 数据；
+- 将主面板、Widget、Tooltip 与辅助功能文案中的“本周剩余”统一调整为
+  “本周期剩余” / `Period Remaining`，兼容 5 小时、7 天和后续可变周期；
+- 新增发布打包门禁：未嵌入 provisioning profile 时，拒绝使用非团队
+  前缀 App Group 的直接分发包。
+
+发布资产：
+
+- 文件名：`QuotaView-v0.3.1-build.2.zip`
+- 大小：`11,443,325 bytes`
+- SHA-256：
+  `9051b60799a5a20e578c2eea4e3f3a5b3725109b553fc8580473953c0f59a1ed`
+- App、Widget Extension 与 `QuotaViewActivityHook` 均为 Universal
+  `x86_64 arm64`
+- App、Widget 与 Helper 均为 `0.3.1 (2)`
+- Developer ID 签名：`Developer ID Application: Chenchen Xu
+  (BUUH229D5Q)`，启用 Hardened Runtime
+- Apple 公证：Accepted，已 Staple；Submission
+  `0ff9bf81-3570-4243-b3be-5d076b0f888c`
+- GitHub 回下载资产与本地正式包逐字节一致；隔离属性下通过
+  `codesign`、`stapler`、`spctl` 与真实启动烟雾测试
+
+Release：
+[QuotaView 0.3.1 Build 2 — Widget Hotfix](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.1-build.2)
+
 ## 0.3.1 (Build 1)
 
 Tag：`v0.3.1`
 
-状态：当前最新正式 Release、GitHub Latest、非 Draft、非 Pre-release。
+状态：历史正式 Release，已由 `0.3.1 (Build 2)` 取代。
 
 发布提交：
 `041c698ae9755d458fa9f111e4ac74e9711048b9`


### PR DESCRIPTION
## Summary

- point the English and Simplified Chinese README download links to the public Build 2 asset
- add a concise bilingual Build 2 widget hotfix summary
- promote Build 2 to the current production baseline in `HANDOFF.md` and `VERSION_HISTORY.md`
- record the release commit, asset size, SHA-256, signing, notarization, and GitHub re-download verification

## Verification

- GitHub Latest is `v0.3.1-build.2`, non-draft and non-pre-release
- the GitHub asset is byte-for-byte identical to the notarized local package
- README links, Handoff, and version history agree on the tag, commit, filename, size, and SHA-256
- `git diff --check` passed

This is a documentation-only follow-up; source code, resources, configuration, and build scripts are unchanged.
