### PR TITLE
docs: record 0.3.2 Preview 1 release

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -6,8 +6,11 @@
 
 当前生产分支：`main`
 
-当前发布提交与生产基线：
+当前稳定发布提交与生产基线：
 `3119171f45163fe45d68a4f774a0488968f14fd7`
+
+当前预览发布提交：
+`f835bcd46a3d0197e9dc09e0b5a25a6d5d69521c`
 
 当前开发提交不在本文固化；每次会话使用 `git branch --show-current` 和
 `git rev-parse HEAD` 读取，避免 Handoff 在合并后立即陈旧。
@@ -30,6 +33,19 @@
 | Release | [QuotaView 0.3.1 Build 2 — Widget Hotfix](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.1-build.2) |
 | 资产 | `QuotaView-v0.3.1-build.2.zip` |
 | SHA-256 | `9051b60799a5a20e578c2eea4e3f3a5b3725109b553fc8580473953c0f59a1ed` |
+
+当前公开预览版为：
+
+| 项目 | 当前值 |
+|---|---|
+| 最新预览版本 | `0.3.2 (Build 1) Preview 1` |
+| tag | `v0.3.2-preview.1` |
+| 发布提交 | `f835bcd46a3d0197e9dc09e0b5a25a6d5d69521c` |
+| Release | [QuotaView 0.3.2 Preview 1 — Multi-task Codex Island](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.2-preview.1) |
+| 资产 | `QuotaView-v0.3.2-preview.1.zip`，`11,543,516 bytes` |
+| SHA-256 | `e39b0d004c2ce2d7d739f5b1f1dc9037335c63d2ee6d663d8129327433f13587` |
+| 公证 | Apple Accepted，已 Staple；Submission `47c6d413-465f-4632-b7d2-1e48ed03f9a0` |
+| 发布状态 | GitHub Pre-release、非 Draft、非 Latest |
 
 `0.3.1 (Build 2)` 已完成 Developer ID 签名、Apple 公证、Staple、
 GitHub Release、Latest 切换和 GitHub 回下载复核，是当前公开生产基线。
@@ -63,26 +79,26 @@ SDD 唯一规格索引：
 | 项目 | 当前值 |
 |---|---|
 | 公开生产基线 | `0.3.1 (Build 2)`，已发布且保持不变 |
-| 当前进行中工作 | Codex 灵动岛多任务适配 |
+| 当前进行中工作 | `0.3.2 Preview 1` 已发布；响应速度与任务跟随优化待后续迭代 |
 | 当前规格 | `QV-PRODUCT-ACTIVITY-ISLAND-MULTITASK-001` |
 | 规格状态 | `Accepted`：固定单岛方向和当前 Demo 视觉/交互基线已确认 |
-| 交付状态 | `Verifying`：核心生产实现、自动化和状态轮播已通过，正在完成预览版发布门禁 |
+| 交付状态 | `Released`：签名、公证、tag、Pre-release 与回下载验证已完成 |
 | Prototype | `Prototypes/CodexActivityMultiTaskDemo/` |
 | Prototype 验证 | `swift test --package-path Prototypes/CodexActivityMultiTaskDemo`：38 项通过，0 失败；当前 8 任务调试界面等待产品所有者验收 |
 | 生产源码 | 已迁入按 `sessionHash` 隔离的任务注册表、自动优先级、可选当前任务跟随、固定单岛任务列和紧凑态入口 |
-| 生产测试与验收 | `swift test`：60 项通过、0 失败；Universal Xcode Release、静态门禁和 Developer ID 本地签名候选包通过；产品所有者已确认一次生产实机状态轮播通过，其余视觉/交互矩阵继续验收 |
+| 生产测试与验收 | `swift test`：60 项通过、0 失败；Universal Xcode Release、静态门禁、Developer ID 签名、Apple 公证、Staple 与 GitHub 回下载验证通过；产品所有者已确认一次生产实机状态轮播通过，其余视觉/交互矩阵作为预览版后续优化证据 |
 | 状态轮播验收 | `2026-08-05` 在已安装的 `0.3.2 Preview 1` 上通过本地认证 Hook 依次验证待命、思考、工作、压缩上下文、等待确认、已完成与 SessionEnd 清理；产品所有者结论：通过；测试事件标题明确标记 `DEBUG-ONLY-MOCK`，源码无残留 |
-| 本地验收候选包 | `dist/QuotaView-v0.3.2-preview.1.zip`；SHA-256 `b74bb5efe46b82992f60fe629edeffabe8eb30842b97a8adb8dfe023e8838909`；Developer ID 签名、未公证；已安装并从 `/Applications/QuotaView.app` 运行 |
-| 目标版本 | `0.3.2 (Build 1) Preview 1`；发布已获授权，计划 tag `v0.3.2-preview.1`，尚未创建 Release |
+| 正式预览资产 | `dist/QuotaView-v0.3.2-preview.1.zip`；`11,543,516 bytes`；SHA-256 `e39b0d004c2ce2d7d739f5b1f1dc9037335c63d2ee6d663d8129327433f13587`；Developer ID 签名、Apple 公证并已 Staple |
+| 已发布版本 | `0.3.2 (Build 1) Preview 1` / `v0.3.2-preview.1` / [GitHub Pre-release](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.2-preview.1) |
 | 稳定回滚基线 | `0.3.1 (Build 2)` / `v0.3.1-build.2` / `3119171f45163fe45d68a4f774a0488968f14fd7` |
 
 用户已于 `2026-08-05` 明确授权迁入生产并指定 `0.3.2 Preview 1`，并在
 状态轮播通过后授权按预览版发布。固定单岛、右侧任务列表、最大态
 `496 × 152 pt`、紧凑态 `52 pt`、最小 AX 标题读取与不控制 Codex 等冻结
 方向继续有效。当前版本基本完成多任务支持，但响应速度、当前任务跟随、
-任务切换与收展节奏仍需优化，因此不得标记为稳定版。当前只生成了
-Developer ID 本地验收签名包；完成公证、tag、GitHub Pre-release 和回下载
-验证后才能把交付状态写为 `Released`。
+任务切换与收展节奏仍需优化，因此不得标记为稳定版。最终资产已经完成
+Developer ID 签名、Apple 公证、Staple、GitHub Pre-release 上传与回下载
+逐字节复核；`0.3.1 (Build 2)` 继续保持 GitHub Latest 和 README 默认下载。
 
 当前规格与执行流程：
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ The universal app supports macOS 14 or later on both Apple Silicon and Intel Mac
 > Island behavior. v0.3.1 Build 2 remains the recommended stable version and
 > the default download.
 
+[Download QuotaView 0.3.2 Preview 1](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.2-preview.1)
+
 The core multi-task workflow is now available in one fixed Codex Island:
 
 - Tracks multiple concurrent Codex sessions with independent status,

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -88,6 +88,8 @@ Universal 应用支持 macOS 14 或更高版本，同时兼容 Apple 芯片和 I
 > 0.3.2 Preview 1 是用于验证 Codex 灵动岛多任务体验的抢先预览版。
 > v0.3.1 Build 2 继续作为推荐稳定版和默认下载版本。
 
+[下载 QuotaView 0.3.2 Preview 1](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.2-preview.1)
+
 当前版本已经在一个固定灵动岛内基本实现完整的多任务工作流：
 
 - 同时跟踪多个 Codex 会话，并分别维护状态、生命周期、完成与清理；

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -29,15 +29,31 @@
 | 发布状态 | 正式 Release、Latest、非 Draft、非 Pre-release |
 | 稳定基线状态 | `0.3.2 Preview 1` 整个开发周期的封存回滚基线 |
 
+当前公开预览版：
+
+| 项目 | 当前值 |
+|---|---|
+| 最新预览版本 | `0.3.2 (Build 1) Preview 1` |
+| Git tag | `v0.3.2-preview.1` |
+| Tag commit | `f835bcd46a3d0197e9dc09e0b5a25a6d5d69521c` |
+| GitHub Release | [QuotaView 0.3.2 Preview 1 — Multi-task Codex Island](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.2-preview.1) |
+| Release 资产 | `QuotaView-v0.3.2-preview.1.zip` |
+| 资产大小 | `11,543,516 bytes` |
+| SHA-256 | `e39b0d004c2ce2d7d739f5b1f1dc9037335c63d2ee6d663d8129327433f13587` |
+| 最低系统版本 | macOS 14 |
+| 架构 | Universal `arm64 + x86_64` |
+| 签名 | `Developer ID Application: Chenchen Xu (BUUH229D5Q)`，启用 Hardened Runtime |
+| 公证 | Apple Accepted，已 Staple；Submission `47c6d413-465f-4632-b7d2-1e48ed03f9a0` |
+| 发布状态 | GitHub Pre-release、非 Draft、非 Latest |
+
 > 当前生产版本为 `0.3.1 (Build 2)`。该热修复保留 Codex 灵动岛，并恢复
 > Developer ID 直接分发环境中的 Widget 数据共享。开发、验证与发布记录见
 > [HANDOFF.md](HANDOFF.md#1-031-build-2-正式发布状态)。
 
-> 当前正在进行的“Codex 灵动岛多任务适配”已进入生产 `Verifying`。
-> 产品所有者已确认按 `0.3.2 Preview 1` 的预览边界发布，并要求公开记录
-> 响应速度与当前任务跟随仍需优化；尚未创建 tag 或 GitHub Pre-release，因此
-> 不进入本文件的版本总览。`0.3.1 (Build 2)` 继续作为公开稳定版、Latest
-> 与封存回滚基线。开发状态以
+> “Codex 灵动岛多任务适配”已作为 `0.3.2 Preview 1` 发布，交付状态为
+> `Released`。响应速度、当前任务跟随、任务切换与收展节奏仍是公开已知
+> 不足，因此该版本不晋升为稳定版。`0.3.1 (Build 2)` 继续作为公开稳定版、
+> GitHub Latest、README 默认下载与封存回滚基线。当前状态以
 > [SDD 当前状态快照](docs/specs/README.md#2-当前状态快照) 为准。
 
 ### 版本定位规则
@@ -58,6 +74,7 @@
 
 | 版本 | 日期（Asia/Shanghai） | 状态 | 核心定位 |
 |---|---|---|---|
+| `0.3.2 (Build 1) Preview 1` | 2026-08-05 | **当前预览版** | Codex 灵动岛多任务支持与可选当前任务跟随 |
 | `0.3.1 (Build 2)` | 2026-08-01 | **当前最新** | Widget 共享容器热修复与可变额度周期文案 |
 | `0.3.1 (Build 1)` | 2026-07-30 | 历史正式版 | Codex 灵动岛实时任务状态与官方 Hooks 连接 |
 | `0.2.1 (Build 1)` | 2026-07-30 | 历史正式版 | 原生 WidgetKit 小组件与 Developer ID 公证分发 |
@@ -67,6 +84,52 @@
 | `0.1.5 (Build 6)` | 2026-07-27 | 历史正式版 | 原生菜单面板、玻璃外观、设置窗口和状态标签热修复 |
 | `0.1.3` | 2026-07-26 | 历史正式版 | 设置、外观、语言、图标和发布流程完善 |
 | `0.1.0` | 2026-07-26 | 首个公开版本 | Codex 额度、Credits、Token 与重置时间基础能力 |
+
+## 0.3.2 (Build 1) Preview 1
+
+Tag：`v0.3.2-preview.1`
+
+状态：当前公开预览版、非 Draft、非 Latest；`0.3.1 (Build 2)` 继续作为
+推荐稳定版与 GitHub Latest。
+
+发布提交：
+`f835bcd46a3d0197e9dc09e0b5a25a6d5d69521c`
+
+主要特性：
+
+- 在一个固定 Codex 灵动岛内同时跟踪多个会话，并分别维护状态、生命周期、
+  完成与清理；
+- 新增三行任务列、连续滑动窗口、任务总数和紧凑态多任务摘要；
+- 使用稳定优先级仲裁主任务，减少普通后台事件对当前任务的无必要抢占；
+- 新增可选的当前 Codex 任务跟随，通过有界、只读的辅助功能标题匹配实现，
+  无法高置信度匹配时安全自动降级；
+- 保留实时 Metal 状态表面、原生玻璃切换、最大态/紧凑态、Reduce Motion
+  和辅助功能操作。
+
+预览版已知不足：
+
+- 事件到灵动岛的响应速度仍可能受 Hook 传递、本机调度和当前任务状态影响；
+- 当前任务跟随基于标题，标题未解析、重复、快速变化或 Codex UI 调整时
+  可能滞后或未命中；
+- 任务切换、长标题跑马灯及最大态/紧凑态切换节奏仍需继续优化。
+
+发布资产：
+
+- 文件名：`QuotaView-v0.3.2-preview.1.zip`
+- 大小：`11,543,516 bytes`
+- SHA-256：
+  `e39b0d004c2ce2d7d739f5b1f1dc9037335c63d2ee6d663d8129327433f13587`
+- App、Widget Extension 与 `QuotaViewActivityHook` 均为 Universal
+  `x86_64 arm64`，App 与 Widget 为 `0.3.2 (1)`、渠道 `preview`
+- Developer ID 签名：`Developer ID Application: Chenchen Xu
+  (BUUH229D5Q)`，启用 Hardened Runtime
+- Apple 公证：Accepted，已 Staple；Submission
+  `47c6d413-465f-4632-b7d2-1e48ed03f9a0`
+- GitHub 回下载资产与本地正式包逐字节一致，并再次通过 `codesign`、
+  `stapler` 与 `spctl` 验证
+
+Release：
+[QuotaView 0.3.2 Preview 1 — Multi-task Codex Island](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.2-preview.1)
 
 ## 0.3.1 (Build 2)
 

--- a/docs/design/quotaview-codex-activity-island-multitask.md
+++ b/docs/design/quotaview-codex-activity-island-multitask.md
@@ -6,7 +6,7 @@
 >
 > 规格状态：`Accepted`（固定单岛结构、视觉与动效 Demo 基线已确认）
 >
-> 交付状态：`Verifying`（`0.3.2 Preview 1` 发布门禁）
+> 交付状态：`Released`（`0.3.2 Preview 1`）
 >
 > 依赖基线：QuotaView `0.3.1 (Build 2)`
 >
@@ -39,28 +39,28 @@
 本文记录产品所有者已确认的 Demo 基线及其生产映射。用户已于
 `2026-08-05` 明确授权迁入生产，并指定 `0.3.2 Preview 1` 为目标版本；
 产品所有者已接受当前多任务能力及响应速度、当前任务跟随仍需优化的预览
-边界，并授权发布 `0.3.2 Preview 1`。当前实现、测试和构建仍不代表已经
-对外发布。任何发布状态仍以项目根目录的
+边界，并授权发布 `0.3.2 Preview 1`。该版本已通过签名、公证、Staple、
+tag、GitHub Pre-release 与回下载验证并正式对外发布。发布状态以项目根目录的
 `HANDOFF.md`、`VERSION_HISTORY.md` 与 [SDD 规格索引](../specs/README.md)
 为准。
 
-本规格及其 Demo 自提交 `f603c38` 起已由 Git 跟踪。生产实现位于
-`codex/0.3.2-preview.1` 开发分支；公开稳定版与回滚基线继续是
+本规格及其 Demo 自提交 `f603c38` 起已由 Git 跟踪。生产实现已合并至
+`main`，发布 tag 为 `v0.3.2-preview.1`；公开稳定版与回滚基线继续是
 `v0.3.1-build.2`，当前工作不得移动该 tag 或覆盖其发布资产。
 
 ## MULTITASK-00.1 SDD 状态与授权边界
 
 本规格的产品方向和当前 Demo 视觉基线已经接受，因此规格状态为
-`Accepted`；交付已进入 `Verifying`。这两个状态不得合并解释：
+`Accepted`；交付已进入 `Released`。这两个状态不得合并解释：
 
-- 当前可以按 Requirement ID 修改生产 `Sources/`、生产测试、版本配置、
-  构建脚本，以及继续维护独立 Demo 证据；
+- 当前生产行为已由 `v0.3.2-preview.1` 固化；后续生产修改必须进入新的
+  迭代、Build、tag 和发布资产；
 - 当前 Demo 控制面板提供 `1–8` 个纯模拟任务并默认展示八项，用于验证
   三行任务视窗在更长列表中的连续滚动；这不构成生产任务数量上限；
 - Demo fixture、控制面板、自动状态轮转与临时 QA 入口不得进入生产；
 - Prototype 测试与生产测试必须继续分开记录；
-- 已授权目标身份为 `0.3.2 (Build 1) Preview 1`，并已授权创建最终 tag、
-  签名、公证和 GitHub Pre-release；
+- `0.3.2 (Build 1) Preview 1` 已完成最终 tag、签名、公证、GitHub
+  Pre-release 与回下载验证；
 - 调试若需要改变 `MULTITASK-14` 的冻结项，必须先取得产品所有者确认并
   更新规格；
 - 只有完成生产自动化、Universal Release 和代码门禁后，交付状态才能进入
@@ -508,10 +508,10 @@ Metal 状态过渡，但不得恢复竖向分隔线、增加常驻背层卡片�
 | `MT-A11Y-001` | VoiceOver Press 和 Reduce Motion Demo | `CodexActivityIsland.swift`、`SettingsView.swift` | 生产编译与状态测试 | 标签、Press 与 Reduce Motion 已接入；矩阵待验收 |
 | `MT-VERIFY-001` | Prototype XCTest 38 项通过；Demo Design QA | 上述生产路径 | `swift test` 60 项通过、0 失败；Universal Release、静态门禁、Developer ID 本地签名候选包和六状态实机轮播通过 | 其余实机产品验收继续进行 |
 
-当前追踪已进入 `Verifying`。生产构建、静态门禁、本地签名候选包与核心
-状态轮播已经通过；响应速度、当前任务跟随、任务切换与收展节奏作为预览版
-已知不足继续优化。签名、公证、tag、GitHub Pre-release 和回下载验证完成
-前，不得提前写成 `Released`。
+当前追踪已进入 `Released`。生产构建、静态门禁、核心状态轮播、Developer
+ID 签名、Apple 公证、Staple、tag、GitHub Pre-release 和回下载验证已经
+通过；响应速度、当前任务跟随、任务切换与收展节奏作为预览版已知不足进入
+后续优化，不得把本版本改写为稳定版。
 
 ## MULTITASK-14. 变更控制
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -12,7 +12,7 @@
 >
 > 当前进行中工作：Codex 灵动岛多任务适配
 >
-> 当前交付阶段：`Verifying`（`0.3.2 Preview 1` 发布门禁）
+> 当前交付阶段：`Released`（`0.3.2 Preview 1`）
 
 ## 1. 本文件的职责
 
@@ -34,8 +34,7 @@
 
 正式 SDD 系统只接纳已经由 Git 跟踪、且在本注册表或阅读路由中具有明确
 职责的 Markdown。当前 SDD 治理、规格和多任务 Demo 文档自提交 `f603c38`
-起已进入 `main`；用户于 `2026-08-05` 授权将多任务能力迁入生产，当前生产
-实现位于独立预览分支，仍不得把未完成的构建写成已发布。
+起已进入 `main`；多任务生产实现已合并并作为 `0.3.2 Preview 1` 发布。
 
 以下本地对象默认排除在正式调用链外：未跟踪的旧
 `Prototypes/CodexActivityMetalDemo/`、受 `AGENTS.md` 门禁约束的未跟踪
@@ -49,15 +48,15 @@
 | 公开生产版本 | `0.3.1 (Build 2)` |
 | 生产版本状态 | 已发布；GitHub Latest；Developer ID 签名并完成 Apple 公证 |
 | 当前开发代码版本 | `MARKETING_VERSION = 0.3.2`，`CURRENT_PROJECT_VERSION = 1`，渠道 `preview` |
-| 当前迭代 | Codex 灵动岛多任务适配 |
+| 当前迭代 | `0.3.2 Preview 1` 已发布；响应速度与任务跟随优化待后续迭代 |
 | 当前规格 | `QV-PRODUCT-ACTIVITY-ISLAND-MULTITASK-001` |
 | 规格状态 | `Accepted`：固定单岛、多任务列表和 Demo 视觉基线已确认 |
-| 交付状态 | `Verifying`：核心实现、自动化和状态轮播已通过，正在完成预览版发布门禁 |
+| 交付状态 | `Released`：签名、公证、tag、Pre-release 与回下载验证已完成 |
 | Prototype 自动化 | 38 项测试通过，0 失败（2026-08-04）；不能替代生产测试 |
 | 生产源码状态 | 已接入任务注册表、独立生命周期、自动优先级、可选 AX 标题跟随、固定任务列和紧凑态入口 |
-| 生产自动化 | `swift test` 60 项通过、0 失败（2026-08-05）；Universal Xcode Release、静态门禁和 Developer ID 本地签名候选包通过，App、Widget、Hook、Core 均为 `x86_64 arm64` |
-| 本地验收候选包 | `dist/QuotaView-v0.3.2-preview.1.zip`；Developer ID 签名、未公证；已安装运行，仅用于产品验收 |
-| 发布目标 | `0.3.2 (Build 1) Preview 1`；发布已获授权，计划 tag `v0.3.2-preview.1`，尚未创建 |
+| 生产自动化 | `swift test` 60 项通过、0 失败（2026-08-05）；Universal Xcode Release、静态门禁、Developer ID 签名、Apple 公证、Staple 与 GitHub 回下载验证通过，App、Widget、Hook、Core 均为 `x86_64 arm64` |
+| 正式预览资产 | `QuotaView-v0.3.2-preview.1.zip`；`11,543,516 bytes`；SHA-256 `e39b0d004c2ce2d7d739f5b1f1dc9037335c63d2ee6d663d8129327433f13587`；Apple Accepted 并已 Staple |
+| 已发布版本 | `0.3.2 (Build 1) Preview 1` / `v0.3.2-preview.1` / [GitHub Pre-release](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.2-preview.1) |
 | 稳定回滚基线 | `0.3.1 (Build 2)` / `v0.3.1-build.2` / `3119171f45163fe45d68a4f774a0488968f14fd7` |
 | 当前验收 | Demo 基线已有产品所有者确认；`2026-08-05` 生产实机六状态轮播与 SessionEnd 清理已由产品所有者确认通过；语言、Widget 状态共享、辅助功能及完整交互矩阵继续验收 |
 
@@ -67,8 +66,8 @@
   [`Prototypes/CodexActivityMultiTaskDemo`](../../Prototypes/CodexActivityMultiTaskDemo/README.md)，
   与生产 Target 隔离；
 - 当前允许按已接受规格修改生产 `Sources/`、测试、版本配置和预发布构建脚本；
-- 用户已明确授权创建 `v0.3.2-preview.1` 与 GitHub Pre-release；在签名、
-  公证、资产验证和 Release 实际完成前，不得把计划资产写成发布事实；
+- `v0.3.2-preview.1`、公证资产和 GitHub Pre-release 已完成并视为不可移动
+  发布事实；后续优化必须使用新的迭代、Build、tag 和资产；
 - Demo 的冻结产品方向继续有效；调试可以修复实现偏差，但改变固定单岛、
   尺寸、任务列、隐私或交互方向必须先更新规格并取得产品所有者确认；
 - 当前工作不得改变 `0.3.1 (Build 2)` 的发布事实。
@@ -106,7 +105,7 @@
 |---|---|---|---|---|---|
 | `QV-GOVERNANCE-001` | [AGENTS.md](../../AGENTS.md) | 治理规范 | `Accepted` | — | 长期产品、实现、验证与发布约束 |
 | `QV-PRODUCT-ACTIVITY-ISLAND-001` | [单任务灵动岛产品规格](../design/quotaview-codex-activity-widget-product.md) | 已发布功能规格 | `Accepted` | `Released` | `0.3.1` 单任务生产行为基线 |
-| `QV-PRODUCT-ACTIVITY-ISLAND-MULTITASK-001` | [多任务灵动岛规格](../design/quotaview-codex-activity-island-multitask.md) | 当前功能规格 | `Accepted` | `Verifying` | `0.3.2 Preview 1` 发布门禁 |
+| `QV-PRODUCT-ACTIVITY-ISLAND-MULTITASK-001` | [多任务灵动岛规格](../design/quotaview-codex-activity-island-multitask.md) | 当前功能规格 | `Accepted` | `Released` | `0.3.2 Preview 1` 已发布行为基线 |
 | `QV-DESIGN-WIDGET-001` | [WidgetKit 接入规格](../design/quotaview-widgetkit-solution.md) | 架构/功能规格 | `Accepted` | `Released` | Widget 数据、Target 与验证边界 |
 | `QV-EXEC-CORE-002` | [核心架构演进规格](../design/quotaview-core-architecture-evolution.md) | 架构规格 | `Accepted` | `Released`（仅 Phase 0–2、4A–4B） | 当前核心架构不变量；Phase 3、5–7 尚未实施 |
 | `QV-EVIDENCE-CORE-0.2.0-001` | [0.2.0 重构报告](../design/quotaview-core-refactor-0.2.0-report.md) | 验证证据 | `Archived` | `Released` | 历史实施与测试证据 |
@@ -138,11 +137,11 @@
 | `MT-MOTION-001` | 任务列、玻璃选择态、Metal 与 Reduce Motion | 生产任务列、选择玻璃、跑马灯和静态降级 | 六状态生产实机轮播通过；Reduce Motion 与完整节奏矩阵继续验收 |
 | `MT-PRIVACY-001` | 最小 AX 标题读取、禁止控制或完整扫描 | 有界顶部标题区读取器 + 设置说明 | 已实现只读降级；待权限授予/撤销实机验收 |
 | `MT-A11Y-001` | VoiceOver、Increase Contrast、Reduce Motion | 生产 AX 标签、Press、Reduce Motion | 首版实现完成；等待产品矩阵验收 |
-| `MT-VERIFY-001` | 自动化、Release 构建、视觉矩阵 | 60 项生产测试、Universal Release、静态门禁、本地签名候选包与六状态实机轮播通过 | 其余产品验收待完成 |
+| `MT-VERIFY-001` | 自动化、Release 构建、视觉矩阵 | 60 项生产测试、Universal Release、静态门禁、六状态实机轮播、Apple 公证、Staple、Pre-release 与回下载验证通过 | 已按预览边界发布；其余产品矩阵进入后续优化证据 |
 
-以上为 `Verifying` 阶段证据。产品所有者已接受以预览版公开当前能力与
-不足；只有签名、公证、tag、GitHub Pre-release 和回下载验证全部完成后，
-才能把当前结果写成 `Released`。
+以上为 `Released` 阶段证据。产品所有者已接受以预览版公开当前能力与
+不足；响应速度、当前任务跟随、任务切换与收展节奏仍是后续优化范围，不能
+据此把 `0.3.2 Preview 1` 改写为稳定版。
 
 ## 6. 阅读路由
 
@@ -160,9 +159,9 @@
 
 ## 7. 一致性规则
 
-- `0.3.1 (Build 2)` 必须继续作为公开稳定版与回滚基线出现在
-  `HANDOFF.md`、`VERSION_HISTORY.md` 和 README；开发配置可以按明确授权
-  使用 `0.3.2 (Build 1) Preview 1`，但不得提前改变公开 Latest；
+- `0.3.1 (Build 2)` 必须继续作为公开稳定版、GitHub Latest 与回滚基线
+  出现在 `HANDOFF.md`、`VERSION_HISTORY.md` 和 README；已发布的
+  `0.3.2 Preview 1` 只能作为独立 Pre-release，不得改变稳定默认下载；
 - 当前迭代、规格状态和交付状态必须同时与 `HANDOFF.md` 一致；
 - 当前开发分支和 HEAD 必须从 Git 实时读取，不得在 Handoff 中维护会随提交
   失效的哈希；


### PR DESCRIPTION
## Summary

- record the completed `0.3.2 (Build 1) Preview 1` release across the version history, handoff, SDD registry, and accepted feature specification
- add stable English and Simplified Chinese README links to the Pre-release while keeping `0.3.1 Build 2` as the default stable download
- preserve the preview's known response-speed, task-following, switching, and transition limitations
- record the immutable tag, release commit, asset size, SHA-256, Developer ID signature, Apple notarization submission, and GitHub release URL

## Release facts

- tag: `v0.3.2-preview.1`
- release commit: `f835bcd46a3d0197e9dc09e0b5a25a6d5d69521c`
- asset: `QuotaView-v0.3.2-preview.1.zip`
- size: `11,543,516 bytes`
- SHA-256: `e39b0d004c2ce2d7d739f5b1f1dc9037335c63d2ee6d663d8129327433f13587`
- notarization: Apple Accepted and stapled, submission `47c6d413-465f-4632-b7d2-1e48ed03f9a0`
- GitHub release: Pre-release, non-draft, not Latest
- stable Latest remains `v0.3.1-build.2`

## Verification

- GitHub-downloaded asset is byte-for-byte identical to the local final ZIP
- downloaded app passed `codesign --verify --deep --strict`, `stapler validate`, and `spctl --assess`
- app, widget, and helper contain `x86_64 arm64`
- documentation-only change; `git diff --check` and cross-document version/status checks passed
