### PR TITLE
test: stabilize async CI coverage

### DIFF
--- a/Tests/QuotaViewCoreTests/AppBehaviorTests.swift
+++ b/Tests/QuotaViewCoreTests/AppBehaviorTests.swift
@@ -400,7 +400,11 @@ final class AppBehaviorTests: XCTestCase {
             )
         )
 
-        try? await Task.sleep(nanoseconds: 40_000_000)
+        for _ in 0..<200 where store.tasks.first(where: {
+            $0.sessionHash == "completed-session"
+        })?.presentation != .compact {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
         XCTAssertEqual(store.tasks.count, 2)
         XCTAssertEqual(
             store.tasks.first {

--- a/Tests/QuotaViewCoreTests/ArchitectureTests.swift
+++ b/Tests/QuotaViewCoreTests/ArchitectureTests.swift
@@ -95,9 +95,10 @@ final class ArchitectureTests: XCTestCase {
 
     func testCoalescedCallersReceiveTheSameAppliedGeneration() async {
         let calls = CallCounter()
+        let fetchGate = FetchGate()
         let provider = StubProvider { request in
             await calls.increment()
-            try await Task.sleep(for: .milliseconds(30))
+            await fetchGate.waitUntilReleased()
             return Self.makeFetchResult(
                 capturedAt: Date(
                     timeIntervalSince1970:
@@ -119,11 +120,14 @@ final class ArchitectureTests: XCTestCase {
             reason: .background,
             policy: .coalesce
         )
-        try? await Task.sleep(for: .milliseconds(5))
         async let second = coordinator.requestRefresh(
             reason: .background,
             policy: .coalesce
         )
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+        await fetchGate.release()
 
         let firstOutcome = await first
         let secondOutcome = await second
@@ -425,6 +429,33 @@ private actor CallCounter {
 
     func increment() {
         value += 1
+    }
+}
+
+private actor FetchGate {
+    private var isReleased = false
+    private var continuations: [CheckedContinuation<Void, Never>] = []
+
+    func waitUntilReleased() async {
+        guard !isReleased else {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            if isReleased {
+                continuation.resume()
+            } else {
+                continuations.append(continuation)
+            }
+        }
+    }
+
+    func release() {
+        isReleased = true
+        let pendingContinuations = continuations
+        continuations.removeAll()
+        for continuation in pendingContinuations {
+            continuation.resume()
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace the fixed 40 ms Codex Island timing assertion with a bounded state wait.
- Keep the provider fetch active with a deterministic gate while coalesced callers join.
- Remove scheduler-sensitive sleeps from the refresh coalescing test.

## Verification

- Affected tests passed in 100 consecutive runs.
- Full swift test: 60 tests passed.
- git diff --check passed.
- No production source files changed.