### PR TITLE
Document 0.3.5 release image

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -181,7 +181,10 @@ GitHub 正式 Release 只使用一份英文源正文，Release URL 为
 `https://github.com/Duoasa/QuotaView/releases/tag/v0.3.5-build.5`。公开产品
 更新介绍截图位于 `Resources/QuotaView-0.3.5-Overview.png`，由中英文 README
 的 0.3.5 章节引用；README 首页另使用
-`Resources/QuotaView-Product-Hero.png` 作为产品主图。
+`Resources/QuotaView-Product-Hero.png` 作为产品主图。GitHub Release 正文
+在开场说明后引用同一更新介绍图，使用不可变提交
+`c060168976930c39dca4af616567fa51eb75d3be` 的 raw URL，避免后续 `main`
+变化造成历史 Release 图片漂移。
 
 正文覆盖：独立 Spark 周额度、主周期内嵌重置、30 日 Tokens 与非账单成本
 估算、半年上限完整 16 列 Token 网格、“最近一天”日期语义、Sparkle 2.9.2
@@ -790,7 +793,8 @@ GitHub 回下载再次验证。
 4. 更新 README 中英文下载入口与 0.3.5 功能说明，并加入产品所有者提供的
    `Resources/QuotaView-Product-Hero.png` 首页产品图和
    `Resources/QuotaView-0.3.5-Overview.png` 更新介绍图；
-5. 确认 GitHub Release Notes 只有一份英文源正文；
+5. 确认 GitHub Release Notes 只有一份英文源正文，并包含上述不可变 0.3.5
+   更新介绍图链接；
 6. 确认已撤回的 `0.2.0 Build 3` 不会重新成为下载或开发基线。
 
 README 下载入口、GitHub Latest 和

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -125,7 +125,9 @@ Tag：`v0.3.5-build.5`
 - 接入 Sparkle 2.9.2 Stable 更新检查、手动检查入口和默认关闭的 24 小时
   自动检查；Debug、Ad Hoc、非 App 或非预期签名环境不访问 Feed；
 - Build Number 从本版开始延续全局递增规则；后续迭代从 Build 6 开始；
-- 产品截图：`Resources/QuotaView-0.3.5-Overview.png`。
+- 产品截图：`Resources/QuotaView-0.3.5-Overview.png`；中英文 README 的
+  0.3.5 更新介绍和 GitHub Release 正文共同引用该图，Release 使用不可变
+  提交 `c060168976930c39dca4af616567fa51eb75d3be` 的 raw URL。
 
 验证与发布资产：
 


### PR DESCRIPTION
## Summary

- record that the v0.3.5 Build 5 GitHub Release notes include the 0.3.5 overview image
- document the immutable raw commit URL used by the historical Release
- keep HANDOFF.md and VERSION_HISTORY.md synchronized

## Spec impact

None. This is documentation synchronization only; the Release tag, signed asset, and public appcast are unchanged.

## Verification

- `git diff --cached --check`
- confirmed the stable Release body contains the image
- confirmed the Release asset name and size are unchanged
- confirmed the public appcast SHA-256 is unchanged
