### PR TITLE
Adopt MIT license and mark QuotaView as open source

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,6 +1,6 @@
 # QuotaView 项目 Handoff
 
-更新日期：2026-08-11
+更新日期：2026-08-12
 
 工作区：`/private/tmp/quotaview-033-build5-estimated-cost`
 
@@ -88,6 +88,11 @@ README 首页产品图为 `Resources/QuotaView-Product-Hero.png`；0.3.5 更新�
 为 `Resources/QuotaView-0.3.5-Overview.png`，两者均用于中英文 README 的
 对应位置。
 完整外观与辅助功能交叉矩阵仍不得记录为全量通过。
+
+2026-08-12：QuotaView 已在 GitHub README 中明确标注为开源项目，仓库根
+目录使用标准 MIT `LICENSE`；中英文 README 均包含 MIT 徽章和许可证入口，
+并已移除不再维护的公开路线图。本次只改变项目文档与授权声明，不改变
+`0.3.5 Build 5` 的源码、版本身份、Release 资产或自动更新 Feed。
 
 2026-08-01：`0.3.1 (Build 2)` Widget 热修复已正式发布。macOS 系统日志
 确认，公开 Build 1 的 Widget 在 Developer ID 直接分发环境中被
@@ -796,6 +801,8 @@ GitHub 回下载再次验证。
 5. 确认 GitHub Release Notes 只有一份英文源正文，并包含上述不可变 0.3.5
    更新介绍图链接；
 6. 确认已撤回的 `0.2.0 Build 3` 不会重新成为下载或开发基线。
+7. 中英文 README 已移除路线图，明确 QuotaView 为开源项目，并共同链接
+   仓库根目录的标准 MIT `LICENSE`。
 
 README 下载入口、GitHub Latest 和
 `VERSION_HISTORY.md#当前最新版本` 当前均指向 `v0.3.5-build.5`。公开

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Duoasa
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111?logo=apple">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white">
+  <a href="LICENSE"><img alt="License: MIT" src="https://img.shields.io/badge/License-MIT-blue.svg"></a>
 </p>
 
 <p align="center">
@@ -21,6 +22,8 @@
   <a href="#privacy-by-design">Privacy</a>
   ·
   <a href="#build-and-test">Build from source</a>
+  ·
+  <a href="#license">Open source</a>
 </p>
 
 <p align="center">
@@ -31,7 +34,7 @@
   <img src="Resources/QuotaView-Product-Hero.png" alt="QuotaView Codex Island live task activity on macOS" width="100%">
 </p>
 
-QuotaView is a simple, lightweight, native macOS companion for the Codex account already signed in on your Mac. **Codex Island** turns live task activity into a glanceable surface beneath the menu bar, while the menu panel and desktop widgets keep period and Spark quota, estimated cost, Credits, token usage, and reset time close at hand. It stays focused without web scraping or reading login credentials from `~/.codex`.
+QuotaView is an open-source, lightweight, native macOS companion for the Codex account already signed in on your Mac. **Codex Island** turns live task activity into a glanceable surface beneath the menu bar, while the menu panel and desktop widgets keep period and Spark quota, estimated cost, Credits, token usage, and reset time close at hand. It stays focused without web scraping or reading login credentials from `~/.codex`.
 
 ## Why QuotaView
 
@@ -345,16 +348,9 @@ Tests/
 └── QuotaViewCoreTests/     # Domain, app behavior, process, and contract tests
 ```
 
-## Roadmap
+## License
 
-- [x] Codex Island live task status
-- [ ] Launch at login with `ServiceManagement`
-- [ ] Historical trends and quota alerts
-- [x] WidgetKit extension backed by an App Group
-- [ ] More AI providers
-- [ ] Separately authorized official account operations
-- [x] Developer ID signing and notarization
-- [ ] Automatic updates
+QuotaView is open-source software released under the [MIT License](LICENSE).
 
 ## Feedback and contributions
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,7 @@
   <a href="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml"><img alt="CI 状态" src="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111?logo=apple">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white">
+  <a href="LICENSE"><img alt="MIT 许可证" src="https://img.shields.io/badge/License-MIT-blue.svg"></a>
 </p>
 
 <p align="center">
@@ -21,6 +22,8 @@
   <a href="#隐私设计">隐私说明</a>
   ·
   <a href="#构建与测试">从源码构建</a>
+  ·
+  <a href="#许可证">开源项目</a>
 </p>
 
 <p align="center">
@@ -31,7 +34,7 @@
   <img src="Resources/QuotaView-Product-Hero.png" alt="QuotaView Codex 灵动岛在 macOS 上实时呈现任务活动" width="100%">
 </p>
 
-QuotaView 是一款简洁、轻量的原生 macOS Codex 助手，使用本机已经登录的 Codex 账户。**Codex 灵动岛**会在菜单栏下方实时呈现任务状态，菜单面板和桌面小组件则让本周期与 Spark 额度、成本估算、Credits、Token 用量和重置时间保持触手可及；不抓取网页，也不读取 `~/.codex` 中的登录凭据。
+QuotaView 是一款开源、轻量的原生 macOS Codex 助手，使用本机已经登录的 Codex 账户。**Codex 灵动岛**会在菜单栏下方实时呈现任务状态，菜单面板和桌面小组件则让本周期与 Spark 额度、成本估算、Credits、Token 用量和重置时间保持触手可及；不抓取网页，也不读取 `~/.codex` 中的登录凭据。
 
 ## 为什么选择 QuotaView
 
@@ -324,16 +327,9 @@ Tests/
 └── QuotaViewCoreTests/     # Domain、应用行为、进程与契约测试
 ```
 
-## 路线图
+## 许可证
 
-- [x] Codex 灵动岛实时任务状态
-- [ ] 使用 `ServiceManagement` 实现登录时启动
-- [ ] 历史趋势和额度提醒
-- [x] 基于 App Group 的 WidgetKit 扩展
-- [ ] 适配更多 AI 服务
-- [ ] 用户单独授权后的官方账户操作
-- [x] Developer ID 签名与公证
-- [ ] 自动更新
+QuotaView 是开源项目，采用 [MIT 许可证](LICENSE)发布。
 
 ## 反馈与贡献
 


### PR DESCRIPTION
## Summary

- remove the public roadmap from the English and Simplified Chinese READMEs
- add a standard MIT license at the repository root
- mark QuotaView as open source in both README introductions, badges, navigation, and license sections
- record the documentation-only project status in `HANDOFF.md`

## Spec impact

None. This is a documentation and licensing change only. It does not change application behavior, version identity, release assets, or the Stable appcast.

## Verification

- compared `LICENSE` with the SPDX MIT template after normalizing the copyright holder and whitespace
- `git diff --check`
- confirmed no Roadmap / 路线图 section remains in either README
- confirmed both READMEs link to the root `LICENSE`
- confirmed Marketing Version `0.3.5` and Build Number `5` are unchanged

Local `swift test` was skipped under the documentation-only exception; GitHub CI remains enabled for this PR.
