### PR TITLE
Record QuotaView 0.3.6 Build 2 release

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,13 +12,13 @@ Release Notes 或完整历史。
 
 | 项目 | 当前值 |
 |---|---|
-| 公开稳定版 | `0.3.5 (Build 5)` / `v0.3.5-build.5` / GitHub Latest |
-| 稳定发布提交 | `58e676a8317d907107af3d1731ab11a0ded52684` |
-| 稳定资产 | `QuotaView-v0.3.5-build.5.zip`；SHA-256 `d8524ddf5739501bd797cdd082cc8738a7775d8b994fe99033068af8f821b2e1` |
-| 稳定回滚基线 | `0.3.3 (Build 3)` / `v0.3.3` / `a93a81af4f90610a57783ceb16a744f07e216c6a` |
+| 公开稳定版 | `0.3.6 (Build 2)` / `v0.3.6-build.2` / GitHub Latest |
+| 稳定发布提交 | `ab033001a194b78e2ec80f31e1f334ea1cae0021` |
+| 稳定资产 | `QuotaView-v0.3.6-build.2.zip`；SHA-256 `b90e05ee724f8adf7856be469476f8b2224304a981c8869e4200aee4ce525bae` |
+| 稳定回滚基线 | `0.3.5 (Build 5)` / `v0.3.5-build.5` / `58e676a8317d907107af3d1731ab11a0ded52684` |
 | 公开预览版 | `0.3.2 Preview 1` / `v0.3.2-preview.1`；不属于稳定源码或 Stable appcast |
-| 当前开发版本 | 产品 `0.3.6 Build 2`；Sparkle 内部更新序号 `CFBundleVersion = 7` |
-| 当前主题 | 单任务灵动岛视觉与个性化设置升级 |
+| 当前开发版本 | 尚未定义；生产配置保持产品 `0.3.6 Build 2` / Sparkle 内部序号 `7` |
+| 当前主题 | 0.3.6 Build 2 已发布，等待下一阶段产品指令 |
 
 产品可见 Build 在 Marketing Version 变化后归 `1`，同一 Marketing Version
 内每次迭代递增；Sparkle 内部更新序号跨 Marketing Version 单调递增。
@@ -28,11 +28,11 @@ Release Notes 或完整历史。
 | 项目 | 当前状态 |
 |---|---|
 | Spec | `QV-PRODUCT-ACTIVITY-ISLAND-004` |
-| 规格 / 交付状态 | `Accepted` / `Verifying` |
+| 规格 / 交付状态 | `Accepted` / `Released` |
 | 当前规格 | [0.3.6 灵动岛升级](docs/design/quotaview-codex-activity-island-0.3.6.md) |
-| 已完成 | 新动画 Demo 定稿；生产灵动岛动画选项；独立显示开关；两段时间设置；自动化与 Universal Build |
+| 已完成 | 新动画 Demo 定稿；生产灵动岛动画选项；独立显示开关；两段时间设置；测试与 Universal Build；Developer ID、公证、Release 与 appcast |
 | 已确认方向 | 只升级当前单任务灵动岛；不加入多任务实验 |
-| 未完成 | Developer ID 打包、公证/Staple、GitHub Stable Release、回下载验证、appcast 部署与最终发布证据 |
+| 未完成 | 完整视觉/辅助功能交叉矩阵，以及真实 0.3.5 → 0.3.6 应用内安装操作的独立验收记录 |
 
 生产分支已经实现：
 
@@ -49,22 +49,22 @@ Release Notes 或完整历史。
 
 更新器规格
 [QV-PRODUCT-APP-UPDATES-003](docs/design/quotaview-app-updates-0.3.5.md)
-并行保持 `Accepted / Verifying`：`0.3.5 Build 5` 已发布更新器和公开 Feed，
-但真实应用内 N → N+1 仍需由后续获准、正式签名、公证且内部序号更高的版本
-完成。
+并行保持 `Accepted / Verifying`：`0.3.5 Build 5` 已发布更新器，`0.3.6
+Build 2` 已作为内部序号更高的第二个正式版本进入公开 Feed；线上版本判断、
+资产和签名链已验证，但真实应用内下载、替换与重启尚未形成独立操作记录。
 
 ## 3. 当前工作区
 
 | 项目 | 当前值 |
 |---|---|
 | 工作区 | `.worktrees/QuotaView-0.3.6-build.1` |
-| 分支 | `codex/0.3.6-build.1-island` |
+| 分支 | `main`（发布证据通过短期文档 PR 回填） |
 | 基线 | `origin/main` |
 | 远程 | `https://github.com/Duoasa/QuotaView.git` |
 
-工作区和分支名保留最初建立 Build 1 时的名称；生产版本身份以配置和本节的
-`0.3.6 Build 2 / CFBundleVersion 7` 为准。开发 HEAD 与状态使用 Git
-命令实时读取，不写入会在提交后立即失效的固定值。
+工作树目录名保留最初建立 Build 1 时的名称；当前代码已合并到 `main`，
+生产版本身份以配置和本节的 `0.3.6 Build 2 / CFBundleVersion 7` 为准。
+开发 HEAD 与状态使用 Git 命令实时读取，不写入会在提交后立即失效的固定值。
 
 多任务 Preview 只保留在：
 
@@ -74,23 +74,31 @@ Release Notes 或完整历史。
 
 ## 4. 当前验证
 
-### 0.3.6 Build 2
+### 0.3.6 Build 2 正式发布
 
 - App 与 Widget：Marketing Version `0.3.6`、产品 Build `2`、Sparkle
   内部 `CFBundleVersion = 7`；
 - `swift test`：66 项通过，0 失败；
-- Universal Xcode Release 无签名构建通过；App、Widget 和 Hook 均为
+- Universal Xcode Release 正式构建通过；App、Widget 和 Hook 均为
   `x86_64 arm64`；
 - App/Widget 包内版本复核均为 `0.3.6 / 7 / 产品 Build 2`；
 - `AppIcon.icns`、`Assets.car` 与新
   `CodexActivityRippleGlowShader.txt` 资源存在；
-- 本地 ad-hoc 验收包 `dist/QuotaView-v0.3.6-build.2.zip` 已生成并从 ZIP
-  全新解压复核；SHA-256
-  `2aacc1beab25ba82899f64d0e44de028e7a6239ada6ad3deaebf84b3050da807`；
-  `codesign --deep --strict`、版本、资源与 Universal 架构通过；未启用
-  Hardened Runtime；
+- 正式资产 `QuotaView-v0.3.6-build.2.zip` 大小 `12,861,638 bytes`，
+  SHA-256
+  `b90e05ee724f8adf7856be469476f8b2224304a981c8869e4200aee4ce525bae`；
+- 使用 Developer ID 证书 SHA-1
+  `E52D0A9C7C377AF77C484155CC0CFCFB27D949D3` 与 Hardened Runtime；Apple
+  notarization `Accepted` 并 Staple，Submission
+  `ff3fef0b-d92f-47cd-8798-3cb388aa2d9e`；
+- GitHub 回下载资产与本地正式 ZIP 逐字节一致；全新解压后通过严格深度
+  签名、Gatekeeper、Staple、版本、资源与 Universal 架构复核；
+- Stable appcast 已部署到 `https://duoasa.github.io/QuotaView/appcast.xml`；
+  `gh-pages` 提交 `421486caac313e04795e429ac36ab14df9d918fd`，Feed
+  SHA-256 `06a9007a3814192deb6469490dadb2b0ca540b3ea6c836a7a623c0107c94a211`；
+  线上文件逐字节一致且 EdDSA 验证通过；
 - 源码搜索未发现 Debug Mock、临时 UI QA、自动展开、自动点击或截图入口；
-- 视觉和交互结论仍为“等待产品所有者验收”。
+- 版本已正式发布；未单独完成的完整视觉/辅助功能矩阵不记录为“已通过”。
 
 ### 0.3.6 Build 1 历史开发基线
 
@@ -101,23 +109,25 @@ Release Notes 或完整历史。
 
 ## 5. 发布与自动更新边界
 
-- `0.3.5 Build 5` 已完成 Developer ID、Hardened Runtime、公证/Staple、
+- `0.3.6 Build 2` 已完成 Developer ID、Hardened Runtime、公证/Staple、
   GitHub Stable/Latest、回下载复核和签名 appcast 部署；证据见
   [VERSION_HISTORY.md](VERSION_HISTORY.md#当前最新版本)；
 - GitHub 推送、tag 或 Release 默认不进入自动更新序列；
 - 只有产品所有者对精确版本、产品 Build、tag 和最终 ZIP 明确批准“纳入自动
   更新序列”后，才同步执行签名、公证、公开 Release 和 appcast 完整门禁；
 - 产品所有者已在 2026-08-23 明确批准 `0.3.6 Build 2` 进入完整稳定发布和
-  自动更新序列，预期身份为 `v0.3.6-build.2` /
-  `QuotaView-v0.3.6-build.2.zip`；发布门禁正在执行，尚未完成的步骤不得
-  提前记录为已发布。
+  自动更新序列；`v0.3.6-build.2` /
+  `QuotaView-v0.3.6-build.2.zip` 的全部发布门禁已完成；
+- 后续版本仍需产品所有者针对精确版本重新授权，不因本次发布自动进入
+  appcast。
 
 ## 6. 下一步
 
-1. 完成 Developer ID、Hardened Runtime、公证/Staple 和最终 ZIP 验证；
-2. 合并并推送 `main`，创建 `v0.3.6-build.2` Stable/Latest Release，
-   回下载验证不可变资产；
-3. 生成、签名并部署 Stable appcast，随后回填全部 Release 与 Feed 证据。
+1. 等待产品所有者定义下一 Marketing Version 与产品 Build；版本变化后
+   产品 Build 归 1，Sparkle 内部序号继续从 7 单调递增；
+2. 如需关闭更新器规格的 `APP-UPDATES-07`，从正式 0.3.5 Build 5 客户端
+   实际执行一次 0.3.6 Build 2 的检查、下载、替换与重启验收；
+3. 完整视觉与辅助功能矩阵仅在产品所有者明确执行并给出结论后记录。
 
 ## 7. 文档入口
 

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -15,29 +15,29 @@
 
 | 项目 | 当前值 |
 |---|---|
-| 最新推荐版本 | `0.3.5 (Build 5)` |
-| Git tag | `v0.3.5-build.5` |
-| Tag commit | `58e676a8317d907107af3d1731ab11a0ded52684` |
-| GitHub Release | [QuotaView 0.3.5 Build 5 — Usage Overview and App Updates](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.5-build.5) |
-| Release 资产 | `QuotaView-v0.3.5-build.5.zip` |
-| 资产大小 | `12,747,358 bytes` |
-| SHA-256 | `d8524ddf5739501bd797cdd082cc8738a7775d8b994fe99033068af8f821b2e1` |
+| 最新推荐版本 | `0.3.6 (Build 2)` |
+| Git tag | `v0.3.6-build.2` |
+| Tag commit | `ab033001a194b78e2ec80f31e1f334ea1cae0021` |
+| GitHub Release | [QuotaView 0.3.6 Build 2 — Customizable Codex Island](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.6-build.2) |
+| Release 资产 | `QuotaView-v0.3.6-build.2.zip` |
+| 资产大小 | `12,861,638 bytes` |
+| SHA-256 | `b90e05ee724f8adf7856be469476f8b2224304a981c8869e4200aee4ce525bae` |
 | 最低系统版本 | macOS 14 |
 | 架构 | Universal `arm64 + x86_64` |
-| 签名 | `Developer ID Application: Chenchen Xu (BUUH229D5Q)`，启用 Hardened Runtime |
-| 公证 | Apple Accepted，已 Staple；Submission `88796026-3227-405a-9e1b-900af973c527` |
+| 签名 | `Developer ID Application: Chenchen Xu (BUUH229D5Q)`，证书 SHA-1 `E52D0A9C7C377AF77C484155CC0CFCFB27D949D3`，启用 Hardened Runtime |
+| 公证 | Apple Accepted，已 Staple；Submission `ff3fef0b-d92f-47cd-8798-3cb388aa2d9e` |
 | 发布状态 | 正式 Release、Latest、非 Draft、非 Pre-release |
-| 自动更新 Feed | [公开 appcast](https://duoasa.github.io/QuotaView/appcast.xml)；Feed SHA-256 `ee46651f1b45fe03cf4e4967543d3b5dd18a644aff956fd5396ea90bd36e2f50`；线上 EdDSA 验证通过 |
+| 自动更新 Feed | [公开 appcast](https://duoasa.github.io/QuotaView/appcast.xml)；`gh-pages` 提交 `421486caac313e04795e429ac36ab14df9d918fd`；Feed SHA-256 `06a9007a3814192deb6469490dadb2b0ca540b3ea6c836a7a623c0107c94a211`；线上 EdDSA 验证通过 |
 
 上一稳定回滚基线：
 
 | 项目 | 封存值 |
 |---|---|
-| 版本 | `0.3.3 (Build 3)` |
-| tag / commit | `v0.3.3` / `a93a81af4f90610a57783ceb16a744f07e216c6a` |
-| Release | [QuotaView 0.3.3 — Token Activity](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.3) |
-| 资产 / SHA-256 | `QuotaView-v0.3.3-build.3.zip` / `ec96964d72d8c37f95cf08170fef83697df83183e36e6be8e23c84e04aa95e12` |
-| 状态 | 不可移动历史正式版；发生 0.3.5 回滚时使用该 tag 与已核验资产 |
+| 版本 | `0.3.5 (Build 5)` |
+| tag / commit | `v0.3.5-build.5` / `58e676a8317d907107af3d1731ab11a0ded52684` |
+| Release | [QuotaView 0.3.5 Build 5 — Usage Overview and App Updates](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.5-build.5) |
+| 资产 / SHA-256 | `QuotaView-v0.3.5-build.5.zip` / `d8524ddf5739501bd797cdd082cc8738a7775d8b994fe99033068af8f821b2e1` |
+| 状态 | 不可移动历史正式版；发生 0.3.6 回滚时使用该 tag 与已核验资产 |
 
 当前公开预览版：
 
@@ -56,24 +56,18 @@
 | 公证 | Apple Accepted，已 Staple；Submission `47c6d413-465f-4632-b7d2-1e48ed03f9a0` |
 | 发布状态 | GitHub Pre-release、非 Draft、非 Latest |
 
-> 当前生产版本为 `0.3.5 (Build 5)`。本版继承 0.3.4 用量概览，包含独立
-> Spark 周额度、30 日 Tokens、成本估算、Token 活动半年上限与完整 16 列
-> 网格，并接入只在预期 Developer ID 正式 App 中启用的 Sparkle 2.9.2
-> Stable 更新器。正式签名、公证/Staple、GitHub Release/Latest、回下载和
-> 公开签名 appcast 均已完成；详细证据见本文件的 `0.3.5 (Build 5)` 章节。
+> 当前生产版本为 `0.3.6 (Build 2)`。本版只升级稳定单任务 Codex 灵动岛，
+> 新增独立显示开关、“粒子球 / 波澜光晕”实时动画选择，以及完成后缩小和
+> 缩小后隐藏时间控制；不迁入多任务 Preview。正式签名、公证/Staple、
+> GitHub Release/Latest、回下载和公开签名 appcast 均已完成；详细证据见
+> 本文件的 `0.3.6 (Build 2)` 章节。
 
-> 当前开发版本为 `0.3.6 (Build 2)` 灵动岛升级。产品可见 Build 在
-> Marketing Version 变化后归 1，同一版本内每次迭代递增；Sparkle 内部
-> 更新序号保持全局递增，本轮 `CFBundleVersion = 7`。动画选择、独立显示
-> 开关与缩小/隐藏时间设置已进入 `Accepted / Verifying`。产品所有者已
-> 明确批准 `v0.3.6-build.2` 进入完整 Stable Release 与 appcast 门禁，
-> 当前仍在发布过程中；正式资产、签名、公证、Release、回下载和 Feed 全部
-> 完成前，不得写入下方正式版本总览，也不改变 `0.3.5 Build 5` 当前已
-> 发布的事实。
+> 下一开发版本尚未定义。生产配置保持 Marketing Version `0.3.6`、产品
+> Build `2` 和 Sparkle 内部更新序号 `7`；不得把计划版本提前写成已发布。
 
 > “Codex 灵动岛多任务适配”已作为 `0.3.2 Preview 1` 发布，交付状态为
 > `Released`。响应速度、当前任务跟随、任务切换与收展节奏仍是公开已知
-> 不足，因此该版本不晋升为稳定版；其实现不包含在 0.3.5 稳定版中。
+> 不足，因此该版本不晋升为稳定版；其实现不包含在 0.3.6 稳定版中。
 > GitHub Pre-release、tag 和本地归档分支继续保留供社区测试和后续开发
 > 参照。当前状态以
 > [SDD 当前状态](docs/specs/README.md#1-当前状态) 为准。
@@ -94,8 +88,9 @@
 
 | 版本 | 日期（Asia/Shanghai） | 状态 | 核心定位 |
 |---|---|---|---|
-| `0.3.5 (Build 5)` | 2026-08-11 | **当前最新** | Spark 与 30 日用量概览、半年 Token 活动、Stable 应用更新检查 |
-| `0.3.3 (Build 3)` | 2026-08-11 | 历史正式版 / 0.3.5 回滚基线 | Token 活动统计、单色方格图与顶部固定动态面板 |
+| `0.3.6 (Build 2)` | 2026-08-23 | **当前最新** | 单任务 Codex 灵动岛动画、显示与事件时间个性化 |
+| `0.3.5 (Build 5)` | 2026-08-11 | 历史正式版 / 0.3.6 回滚基线 | Spark 与 30 日用量概览、半年 Token 活动、Stable 应用更新检查 |
+| `0.3.3 (Build 3)` | 2026-08-11 | 历史正式版 | Token 活动统计、单色方格图与顶部固定动态面板 |
 | `0.3.2 (Build 1) Preview 1` | 2026-08-05 | **当前预览版** | Codex 灵动岛多任务支持与可选当前任务跟随 |
 | `0.3.1 (Build 2)` | 2026-08-01 | 历史正式版 / 0.3.3 回滚基线 | Widget 共享容器热修复与可变额度周期文案 |
 | `0.3.1 (Build 1)` | 2026-07-30 | 历史正式版 | Codex 灵动岛实时任务状态与官方 Hooks 连接 |
@@ -107,12 +102,68 @@
 | `0.1.3` | 2026-07-26 | 历史正式版 | 设置、外观、语言、图标和发布流程完善 |
 | `0.1.0` | 2026-07-26 | 首个公开版本 | Codex 额度、Credits、Token 与重置时间基础能力 |
 
+## 0.3.6 (Build 2)
+
+Tag：`v0.3.6-build.2`
+
+状态：当前最新正式 Release、GitHub Latest、非 Draft、非 Pre-release；
+已进入公开 Stable appcast。
+
+发布提交：
+`ab033001a194b78e2ec80f31e1f334ea1cae0021`
+
+主要特性：
+
+- 在设置页新增独立“显示灵动岛”开关；关闭只隐藏窗口，Codex Hook、Socket
+  和本地状态连接继续工作；
+- 为稳定单任务灵动岛提供“粒子球”和“波澜光晕”两种生产渲染预览，选择
+  后即时切换；
+- “波澜光晕”覆盖现有九种任务状态，保持固定圆形轮廓和连续状态过渡，
+  Metal 不可用时回退“粒子球”；
+- “完成后缩小”支持 5...60 秒，“缩小后隐藏”支持 5...120 秒，均以
+  5 秒为档位并显示刻度与当前值；
+- 保留 Reduce Motion、单一 NSPanel 和现有本地隐私边界；不包含独立的
+  多任务 Preview 实验；
+- 产品 Build 为 2，Sparkle 内部更新序号为 7，可被 0.3.5 Build 5 的
+  Stable 更新器识别为新版本；
+- 产品截图：`Resources/QuotaView-0.3.6-Codex-Island-Settings.png`；中英文
+  README 的 0.3.6 更新介绍与 GitHub Release 正文共同引用该图。
+
+验证与发布资产：
+
+- `swift test`：66 项通过、0 失败；PR #27 与签名修复 PR #28 GitHub CI
+  均通过；
+- 文件名：`QuotaView-v0.3.6-build.2.zip`
+- 大小：`12,861,638 bytes`
+- SHA-256：
+  `b90e05ee724f8adf7856be469476f8b2224304a981c8869e4200aee4ce525bae`
+- App、Widget 和 Hook 均为 Universal `x86_64 arm64`；App 为
+  Marketing Version `0.3.6`、内部版本 `7`、产品 Build `2`；
+- Developer ID：`Developer ID Application: Chenchen Xu (BUUH229D5Q)`，
+  证书 SHA-1 `E52D0A9C7C377AF77C484155CC0CFCFB27D949D3`，启用
+  Hardened Runtime；
+- Apple 公证：Accepted，已 Staple；Submission
+  `ff3fef0b-d92f-47cd-8798-3cb388aa2d9e`；
+- GitHub 回下载正式资产与本地公证包逐字节一致；从 ZIP 全新解压后重新
+  通过 `codesign --deep --strict`、Staple、Gatekeeper、版本、架构与资源
+  复核；
+- 公开 Feed：`https://duoasa.github.io/QuotaView/appcast.xml`；`gh-pages`
+  提交 `421486caac313e04795e429ac36ab14df9d918fd`；Feed SHA-256
+  `06a9007a3814192deb6469490dadb2b0ca540b3ea6c836a7a623c0107c94a211`；
+  线上文件与本地签名文件逐字节一致，Feed EdDSA 验证通过；
+- 真实 0.3.5 → 0.3.6 应用内安装操作和完整视觉/辅助功能交叉矩阵尚未形成
+  独立验收记录，因此更新器规格继续保持 `Accepted / Verifying`；不影响
+  本版已经正式发布。
+
+Release：
+[QuotaView 0.3.6 Build 2 — Customizable Codex Island](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.6-build.2)
+
 ## 0.3.5 (Build 5)
 
 Tag：`v0.3.5-build.5`
 
-状态：当前最新正式 Release、GitHub Latest、非 Draft、非 Pre-release；
-已进入公开 Stable appcast。
+状态：历史正式 Release、0.3.6 的封存回滚基线、首个包含更新器的稳定
+版本、非 Draft、非 Pre-release；已由 0.3.6 Build 2 替代。
 
 发布提交：
 `58e676a8317d907107af3d1731ab11a0ded52684`
@@ -213,7 +264,7 @@ Release：
 
 Tag：`v0.3.2-preview.1`
 
-状态：当前公开预览版、非 Draft、非 Latest；`0.3.5 (Build 5)` 是
+状态：当前公开预览版、非 Draft、非 Latest；`0.3.6 (Build 2)` 是
 推荐稳定版与 GitHub Latest。
 
 发布提交：

--- a/docs/design/quotaview-app-updates-0.3.5.md
+++ b/docs/design/quotaview-app-updates-0.3.5.md
@@ -4,7 +4,7 @@
 >
 > 规格状态：`Accepted`
 >
-> 交付状态：`Verifying`（Build 5 已正式发布并上线 Feed；真实 N → N+1 待后续 Build）
+> 交付状态：`Verifying`（Build 5 已发布更新器，Build 2 已作为 0.3.6 更新进入 Feed；真实客户端安装操作待独立记录）
 >
 > 目标版本：`0.3.5 (Build 5)`
 
@@ -60,18 +60,24 @@
   `QuotaView-v0.3.5-build.5.zip`；最终资产 SHA-256、Developer ID、Apple
   公证/Staple、回下载、Feed 签名和线上复核门禁均已完成。后续版本必须
   重新获得精确准入，不得沿用本次授权。
+- 产品所有者已于 `2026-08-23` 明确批准 `0.3.6 Build 2` 进入自动更新
+  序列，准入身份为 tag `v0.3.6-build.2`、资产
+  `QuotaView-v0.3.6-build.2.zip`、产品 Build `2` 和内部更新序号 `7`；
+  Developer ID、公证/Staple、Stable/Latest Release、回下载、Feed EdDSA
+  与线上逐字节复核均已完成。本次准入同样不自动延伸到后续版本。
 
 ## 4. 版本规则
 
 产品可见 Build Number 按 Marketing Version 独立计数：Marketing Version
 变化时归 `Build 1`，同一 Marketing Version 内的后续迭代依次递增。因此
-`0.3.5 Build 5` 的下一 Marketing Version 为 `0.3.6 Build 1`。
+`0.3.5 Build 5` 之后的 `0.3.6` 从 Build 1 开始，本次正式发布的是同一
+Marketing Version 的第二次迭代 `0.3.6 Build 2`。
 
 Sparkle 的[官方升级说明](https://sparkle-project.org/documentation/upgrading/)
 要求 `CFBundleVersion` / `sparkle:version` 使用递增的机器可读版本，因此
-两者继续作为跨 Marketing Version 单调递增的内部更新序号；从
-`0.3.5 Build 5` 到 `0.3.6 Build 1` 时内部序号由 `5` 增至 `6`。产品可见
-Build 由 `QuotaViewDisplayBuildNumber` / `QUOTAVIEW_DISPLAY_BUILD_NUMBER`
+两者继续作为跨 Marketing Version 单调递增的内部更新序号；`0.3.6 Build
+1` 使用内部序号 `6`，`0.3.6 Build 2` 使用内部序号 `7`。产品可见 Build
+由 `QuotaViewDisplayBuildNumber` / `QUOTAVIEW_DISPLAY_BUILD_NUMBER`
 维护，设置界面、tag、ZIP、Handoff 与版本历史使用该值。App、Widget 与
 兼容 Info.plist 必须同时同步 Marketing Version、产品 Build 和内部更新序号。
 
@@ -101,11 +107,11 @@ Build 由 `QuotaViewDisplayBuildNumber` / `QUOTAVIEW_DISPLAY_BUILD_NUMBER`
 `0.3.5 Build 5` 进入自动更新序列，因此本版已完成 Developer ID、Apple
 公证/Staple、GitHub Stable/Latest、回下载、公开 appcast 和文档联动。
 
-Build 5 是首个包含更新器的正式版本，无法单独完成两个正式版本之间的
-N → N+1 验收。因此 `APP-UPDATES-07` 和本规格交付状态保持 `Verifying`，
-直到后续获准且内部更新序号更高的版本完成真实应用内更新；这不影响
-Build 5 版本本身已经 `Released`。后续 GitHub Stable/Latest 仍不自动获得
-appcast 准入。
+Build 5 是首个包含更新器的正式版本，0.3.6 Build 2 是第一个获准且内部
+序号更高的 Stable appcast 条目。版本判断、远端资产和完整签名链已经验证，
+但尚未从真实 0.3.5 客户端记录一次检查、下载、替换与重启全过程。因此
+`APP-UPDATES-07` 和本规格交付状态保持 `Verifying`；这不影响两个版本各自
+已经 `Released`。后续 GitHub Stable/Latest 仍不自动获得 appcast 准入。
 
 ## 8. 当前验证记录
 
@@ -124,8 +130,13 @@ appcast 准入。
 - Sparkle 私钥完成 AES-256 iCloud 加密备份与恢复一致性验证，恢复密码只存
   macOS Keychain；
 - 公开 appcast 已部署到 `https://duoasa.github.io/QuotaView/appcast.xml`，
-  SHA-256 为
-  `ee46651f1b45fe03cf4e4967543d3b5dd18a644aff956fd5396ea90bd36e2f50`；线上
+  当前指向 `0.3.6 Build 2 / sparkle:version 7`，SHA-256 为
+  `06a9007a3814192deb6469490dadb2b0ca540b3ea6c836a7a623c0107c94a211`；线上
   文件与本地签名 Feed 逐字节一致，Feed EdDSA 验证通过；
-- 设置完整视觉/辅助功能矩阵与真实 N → N+1 更新仍未完成，因此规格结论
-  保持 `Verifying`；Build 5 版本发布事实为 `Released`。
+- 0.3.6 正式 ZIP 大小 `12,861,638 bytes`，SHA-256
+  `b90e05ee724f8adf7856be469476f8b2224304a981c8869e4200aee4ce525bae`；
+  Apple notarization `Accepted` 并 Staple，Submission
+  `ff3fef0b-d92f-47cd-8798-3cb388aa2d9e`；GitHub 回下载逐字节一致；
+- 设置完整视觉/辅助功能矩阵与真实客户端 N → N+1 安装操作仍未完成独立
+  记录，因此规格结论保持 `Verifying`；0.3.5 与 0.3.6 的版本发布事实均为
+  `Released`。

--- a/docs/design/quotaview-codex-activity-island-0.3.6.md
+++ b/docs/design/quotaview-codex-activity-island-0.3.6.md
@@ -4,7 +4,7 @@
 >
 > 规格状态：`Accepted`
 >
-> 交付状态：`Verifying`
+> 交付状态：`Released`
 >
 > 目标版本：`0.3.6 (Build 2)`
 >
@@ -75,12 +75,17 @@
   `x86_64 arm64`；App/Widget 均读取为 `0.3.6 / 7 / 产品 Build 2`；
 - `AppIcon.icns`、`Assets.car` 和 `CodexActivityRippleGlowShader.txt` 均已
   进入 App 包；
-- 本地 ad-hoc 验收包为 `dist/QuotaView-v0.3.6-build.2.zip`，SHA-256
-  `2aacc1beab25ba82899f64d0e44de028e7a6239ada6ad3deaebf84b3050da807`；
-  ZIP 全新解压后的深度签名、版本、资源与 Universal 架构复核通过；
-- 代码与自动化验证完成后，交付维持 `Verifying`。设置页排版、两种预览、
-  即时切换、开关和两段计时的视觉/交互结论等待产品所有者运行应用验收；
+- 正式资产为 `QuotaView-v0.3.6-build.2.zip`，大小 `12,861,638 bytes`，
+  SHA-256
+  `b90e05ee724f8adf7856be469476f8b2224304a981c8869e4200aee4ce525bae`；
+- Developer ID、Hardened Runtime、Apple notarization `Accepted` 与 Staple
+  已完成，Submission `ff3fef0b-d92f-47cd-8798-3cb388aa2d9e`；
+- GitHub 回下载 ZIP 与本地正式资产逐字节一致；全新解压后通过严格深度
+  签名、Gatekeeper、Staple、版本、资源与 Universal 架构复核；
 - 产品所有者已在 2026-08-23 明确批准 `0.3.6 Build 2` 进入完整稳定发布
-  和自动更新序列；预期 tag / ZIP 为 `v0.3.6-build.2` /
-  `QuotaView-v0.3.6-build.2.zip`。签名、公证、Release、回下载和 appcast
-  证据只有实际完成后才能回填为已发布。
+  和自动更新序列；`v0.3.6-build.2` Stable/Latest Release 与公开 appcast
+  已发布，Feed SHA-256
+  `06a9007a3814192deb6469490dadb2b0ca540b3ea6c836a7a623c0107c94a211`，线上
+  文件逐字节一致且 EdDSA 验证通过；
+- 本规格交付状态因此进入 `Released`。完整视觉与辅助功能交叉矩阵没有单独
+  记录为全量通过；该未记录项不改写已经发生的 Release 事实。

--- a/docs/design/quotaview-core-architecture-evolution.md
+++ b/docs/design/quotaview-core-architecture-evolution.md
@@ -12,7 +12,7 @@
 >
 > 原始设计基线：QuotaView `0.1.5 (Build 6)`
 >
-> 当前生产基线：QuotaView `0.3.5 (Build 5)`
+> 当前生产基线：QuotaView `0.3.6 (Build 2)`
 >
 > 编写日期：2026-07-28
 >

--- a/docs/design/quotaview-widgetkit-solution.md
+++ b/docs/design/quotaview-widgetkit-solution.md
@@ -7,7 +7,7 @@
 > 文档版本：`2.1`<br>
 > 依赖：`QV-EXEC-CORE-002` Phase 0–2<br>
 > 原始设计基线：QuotaView `0.1.5 (Build 6)`<br>
-> 当前生产基线：QuotaView `0.3.5 (Build 5)`；本版未改变 WidgetKit 数据与界面契约<br>
+> 当前生产基线：QuotaView `0.3.6 (Build 2)`；本版未改变 WidgetKit 数据与界面契约<br>
 > 编写日期：2026-07-28<br>
 > SDD 状态更新：2026-08-04<br>
 > 适用平台：macOS 14 及以上<br>

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -6,9 +6,9 @@
 >
 > 状态：`Accepted`
 >
-> 当前生产基线：`0.3.5 Build 5`
+> 当前生产基线：`0.3.6 Build 2`
 >
-> 当前迭代：`0.3.6 Build 2` 灵动岛升级
+> 当前迭代：`0.3.6 Build 2` 已发布；下一版本尚未定义
 
 本文件只负责定位当前工作和规格，不复制 Release 证据、实现细节或历史
 Requirement 矩阵。
@@ -17,14 +17,14 @@ Requirement 矩阵。
 
 | 项目 | 当前值 |
 |---|---|
-| 公开稳定版 | `0.3.5 Build 5`；事实见 [版本历史](../../VERSION_HISTORY.md#当前最新版本) |
-| 当前开发版本 | 产品 `0.3.6 Build 2`；Sparkle 内部序号 `7` |
+| 公开稳定版 | `0.3.6 Build 2`；事实见 [版本历史](../../VERSION_HISTORY.md#当前最新版本) |
+| 当前开发版本 | 尚未定义；生产配置保持产品 `0.3.6 Build 2` / Sparkle 内部序号 `7` |
 | 当前产品规格 | `QV-PRODUCT-ACTIVITY-ISLAND-004` |
-| 规格 / 交付状态 | `Accepted` / `Verifying` |
+| 规格 / 交付状态 | `Accepted` / `Released` |
 | 当前边界 | 只升级单任务灵动岛；多任务实验已排除；不扩大本地数据与权限边界 |
-| 当前阶段 | 产品验收完成；已批准 `v0.3.6-build.2` 进入完整 Stable Release 与 appcast 门禁，发布进行中 |
+| 当前阶段 | `v0.3.6-build.2` 已完成 Stable Release、回下载验证与 appcast 发布 |
 | 当前设置 | 完成后缩小 5...60 秒；缩小后隐藏 5...120 秒；均为 5 秒档位 |
-| 并行验证 | `QV-PRODUCT-APP-UPDATES-003` 为 `Accepted / Verifying`，等待真实 N → N+1 |
+| 并行验证 | `QV-PRODUCT-APP-UPDATES-003` 为 `Accepted / Verifying`；0.3.6 已进入 Feed，真实客户端安装操作仍待独立记录 |
 
 当前工作区、验证结果和下一步见 [HANDOFF.md](../../HANDOFF.md)。
 
@@ -43,8 +43,8 @@ Requirement 矩阵。
 
 | Spec ID | 文档 | 状态 | 用途 |
 |---|---|---|---|
-| `QV-PRODUCT-ACTIVITY-ISLAND-004` | [0.3.6 灵动岛升级](../design/quotaview-codex-activity-island-0.3.6.md) | `Accepted / Verifying` | 单灵动岛动画选择、显示开关与缩小/隐藏时间设置；等待产品验收 |
-| `QV-PRODUCT-APP-UPDATES-003` | [应用检查与更新](../design/quotaview-app-updates-0.3.5.md) | `Accepted / Verifying` | 已发布更新器；后续获准版本完成真实 N → N+1 |
+| `QV-PRODUCT-ACTIVITY-ISLAND-004` | [0.3.6 灵动岛升级](../design/quotaview-codex-activity-island-0.3.6.md) | `Accepted / Released` | 单灵动岛动画选择、显示开关与缩小/隐藏时间设置；已发布到 Stable |
+| `QV-PRODUCT-APP-UPDATES-003` | [应用检查与更新](../design/quotaview-app-updates-0.3.5.md) | `Accepted / Verifying` | 0.3.6 已进入 Feed；真实客户端安装操作仍待记录 |
 
 ## 4. 已发布与历史参考
 


### PR DESCRIPTION
## Summary
- promote 0.3.6 Build 2 to the current stable release in Handoff and Version History
- record Developer ID, notarization, immutable asset, GitHub Release, and public appcast evidence
- mark the Codex Island feature delivery Released while preserving the unrecorded end-to-end updater acceptance boundary
- refresh archived production-baseline pointers

## Verified release facts
- tag: `v0.3.6-build.2` at `ab033001a194b78e2ec80f31e1f334ea1cae0021`
- ZIP SHA-256: `b90e05ee724f8adf7856be469476f8b2224304a981c8869e4200aee4ce525bae`
- notarization: Accepted and stapled (`ff3fef0b-d92f-47cd-8798-3cb388aa2d9e`)
- appcast SHA-256: `06a9007a3814192deb6469490dadb2b0ca540b3ea6c836a7a623c0107c94a211`
- `git diff --check` passed; documentation-only follow-up