### PR TITLE
Record QuotaView 0.3.7 Build 1 release

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -11,11 +11,11 @@
 
 | 项目 | 当前值 |
 |---|---|
-| 稳定版 | `0.3.6 Build 2` / `v0.3.6-build.2` / GitHub Latest |
-| 回滚基线 | `0.3.5 Build 5` / `v0.3.5-build.5` |
+| 稳定版 | `0.3.7 Build 1` / `v0.3.7-build.1` / GitHub Latest |
+| 回滚基线 | `0.3.6 Build 2` / `v0.3.6-build.2` |
 | 公开预览 | `0.3.2 Preview 1`；不属于稳定源码或 Stable appcast |
-| 当前开发 | `0.3.7 Build 1`；Sparkle 内部序号 `11`；已获本精确版本 appcast 准入，发布链执行中 |
-| 当前主题 | 多周期额度展示与灵动岛多屏定位选项 |
+| 当前开发 | 无；生产配置保持 `0.3.7 Build 1`、Sparkle 内部序号 `11` |
+| 当前主题 | 0.3.7 已发布；等待下一版本目标 |
 
 产品可见 Build 在 Marketing Version 变化后归 `1`，同一版本内逐次递增；
 Sparkle `CFBundleVersion` 跨 Marketing Version 单调递增。
@@ -24,24 +24,15 @@ Sparkle `CFBundleVersion` 跨 Marketing Version 单调递增。
 
 | Spec | 状态 | 结论 / 未完成项 |
 |---|---|---|
-| [`QV-PRODUCT-QUOTA-WINDOWS-003`](docs/design/quotaview-quota-windows-0.3.6-build.3.md) | `Accepted / Verifying` | `codex.primary` 与 `secondary` 已独立建模并按时长显示；纳入 0.3.7 Build 1 发布候选 |
-| [`QV-PRODUCT-ACTIVITY-ISLAND-004`](docs/design/quotaview-codex-activity-island-0.3.6.md) | `Accepted / Verifying` | 0.3.7 Build 1 新增“锁定到 Codex 屏幕”开关；不包含多任务 Preview |
-| [`QV-PRODUCT-APP-UPDATES-003`](docs/design/quotaview-app-updates-0.3.5.md) | `Accepted / Verifying` | 0.3.5 与 0.3.6 已进入 Stable Feed；尚缺一次真实 0.3.5 → 0.3.6 检查、下载、替换与重启记录 |
+| [`QV-PRODUCT-QUOTA-WINDOWS-003`](docs/design/quotaview-quota-windows-0.3.6-build.3.md) | `Accepted / Released` | 多周期额度已随 0.3.7 Build 1 发布并进入 Stable Feed |
+| [`QV-PRODUCT-ACTIVITY-ISLAND-004`](docs/design/quotaview-codex-activity-island-0.3.6.md) | `Accepted / Released` | “锁定到 Codex 屏幕”已随 0.3.7 Build 1 发布；不包含多任务 Preview |
+| [`QV-PRODUCT-APP-UPDATES-003`](docs/design/quotaview-app-updates-0.3.5.md) | `Accepted / Verifying` | 0.3.5、0.3.6 与 0.3.7 已进入 Stable Feed；尚缺一次真实 N → N+1 替换与重启记录 |
 
-`0.3.6 Build 2` 的自动化、Universal、Developer ID、公证/Staple、GitHub
-Release/Latest、回下载与 EdDSA appcast 均已完成，完整证据只在
-[版本历史](VERSION_HISTORY.md#036-build-2) 保存。完整视觉与辅助功能交叉
-矩阵未被记录为全量通过。
-
-`0.3.6 Build 3/4/5` 的开发内容已晋升为 `0.3.7 Build 1` 发布候选，不再
-作为独立候选；Codex 主/次窗口按实际时长从短到长显示，Spark 保持独立。本版进一步
-新增灵动岛屏幕定位：默认跟随热区，也可锁定最大可见 Codex 窗口所在屏幕，
-不可定位时回退热区。72 项测试与 Universal 无签名 Release 构建已通过，
-App、Widget 和 Activity Hook 均为 `x86_64 + arm64`；视觉与多屏交互等待
-产品所有者验收。产品所有者已于 2026-08-26 明确批准精确版本
-`0.3.7 Build 1`（内部序号 `11`、tag `v0.3.7-build.1`、资产
-`QuotaView-v0.3.7-build.1.zip`）进入 Stable appcast；发布事实须在链路完成
-后写入版本历史。
+`0.3.7 Build 1` 的 72 项测试、GitHub CI、Universal、Developer ID、Apple
+公证/Staple、GitHub Release/Latest、回下载、两次启动冒烟与公开 EdDSA
+appcast 均已完成；不可变证据只在
+[版本历史](VERSION_HISTORY.md#037-build-1) 保存。完整视觉与辅助功能交叉
+矩阵，以及真实 0.3.6 → 0.3.7 应用内替换和重启，尚未记录为通过。
 
 ## 3. 长期边界
 
@@ -54,12 +45,12 @@ App、Widget 和 Activity Hook 均为 `x86_64 + arm64`；视觉与多屏交互�
 
 ## 4. 下一步
 
-1. 完成 0.3.7 Build 1 的测试、Universal 构建、Developer ID 签名、Apple
-   公证/Staple、GitHub Latest、回下载与 EdDSA appcast 发布；
-2. 发布完成后把实际 tag 提交、资产大小/SHA-256、公证与 Feed 证据同步到
-   `VERSION_HISTORY.md`，再把本文件收口为已发布状态；
-3. 如需关闭更新器规格的 `APP-UPDATES-07`，使用正式 0.3.5 客户端完成一次
-   到 0.3.6 的真实应用内更新；
+1. 等待产品所有者定义下一 Marketing Version；版本变化后产品 Build 归 1，
+   Sparkle 内部序号必须大于 11；
+2. 如需关闭更新器规格的 `APP-UPDATES-07`，使用正式 0.3.6 客户端完成一次
+   到 0.3.7 的真实应用内检查、下载、替换与重启；
+3. 完整深浅色、多屏、VoiceOver、Increase Contrast 与 Reduce Motion 矩阵
+   仍由产品所有者按需验收；
 4. 新任务从 [SDD 注册表](docs/specs/README.md) 只读取对应的一份当前规格。
 
 ## 5. 文档入口

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -15,29 +15,29 @@
 
 | 项目 | 当前值 |
 |---|---|
-| 最新推荐版本 | `0.3.6 (Build 2)` |
-| Git tag | `v0.3.6-build.2` |
-| Tag commit | `ab033001a194b78e2ec80f31e1f334ea1cae0021` |
-| GitHub Release | [QuotaView 0.3.6 Build 2 — Customizable Codex Island](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.6-build.2) |
-| Release 资产 | `QuotaView-v0.3.6-build.2.zip` |
-| 资产大小 | `12,861,638 bytes` |
-| SHA-256 | `b90e05ee724f8adf7856be469476f8b2224304a981c8869e4200aee4ce525bae` |
+| 最新推荐版本 | `0.3.7 (Build 1)` |
+| Git tag | `v0.3.7-build.1` |
+| Tag commit | `6f6f30a58141deff45a5b2c67546421cba06ad70` |
+| GitHub Release | [QuotaView 0.3.7 Build 1 — Multiple Quota Windows and a Screen-Aware Codex Island](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.7-build.1) |
+| Release 资产 | `QuotaView-v0.3.7-build.1.zip` |
+| 资产大小 | `12,927,829 bytes` |
+| SHA-256 | `42e815cbb12f18112e3423c48f6392232ef25c061cfa9ba96d19012ddaa7b5c4` |
 | 最低系统版本 | macOS 14 |
 | 架构 | Universal `arm64 + x86_64` |
 | 签名 | `Developer ID Application: Chenchen Xu (BUUH229D5Q)`，证书 SHA-1 `E52D0A9C7C377AF77C484155CC0CFCFB27D949D3`，启用 Hardened Runtime |
-| 公证 | Apple Accepted，已 Staple；Submission `ff3fef0b-d92f-47cd-8798-3cb388aa2d9e` |
+| 公证 | Apple Accepted，已 Staple；Submission `04654ab7-29ea-4bda-a131-3363f58fb840` |
 | 发布状态 | 正式 Release、Latest、非 Draft、非 Pre-release |
-| 自动更新 Feed | [公开 appcast](https://duoasa.github.io/QuotaView/appcast.xml)；`gh-pages` 提交 `421486caac313e04795e429ac36ab14df9d918fd`；Feed SHA-256 `06a9007a3814192deb6469490dadb2b0ca540b3ea6c836a7a623c0107c94a211`；线上 EdDSA 验证通过 |
+| 自动更新 Feed | [公开 appcast](https://duoasa.github.io/QuotaView/appcast.xml)；`gh-pages` 提交 `bcff201229d9ce5499f984c0176c6686b4d29d60`；Feed SHA-256 `3e79e1cee579ab87eb84b766374e36de62d9115d4dc75fed22c56b8e1e4a3488`；线上 EdDSA 验证通过 |
 
 上一稳定回滚基线：
 
 | 项目 | 封存值 |
 |---|---|
-| 版本 | `0.3.5 (Build 5)` |
-| tag / commit | `v0.3.5-build.5` / `58e676a8317d907107af3d1731ab11a0ded52684` |
-| Release | [QuotaView 0.3.5 Build 5 — Usage Overview and App Updates](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.5-build.5) |
-| 资产 / SHA-256 | `QuotaView-v0.3.5-build.5.zip` / `d8524ddf5739501bd797cdd082cc8738a7775d8b994fe99033068af8f821b2e1` |
-| 状态 | 不可移动历史正式版；发生 0.3.6 回滚时使用该 tag 与已核验资产 |
+| 版本 | `0.3.6 (Build 2)` |
+| tag / commit | `v0.3.6-build.2` / `ab033001a194b78e2ec80f31e1f334ea1cae0021` |
+| Release | [QuotaView 0.3.6 Build 2 — Customizable Codex Island](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.6-build.2) |
+| 资产 / SHA-256 | `QuotaView-v0.3.6-build.2.zip` / `b90e05ee724f8adf7856be469476f8b2224304a981c8869e4200aee4ce525bae` |
+| 状态 | 不可移动历史正式版；发生 0.3.7 回滚时使用该 tag 与已核验资产 |
 
 当前公开预览版：
 
@@ -56,18 +56,17 @@
 | 公证 | Apple Accepted，已 Staple；Submission `47c6d413-465f-4632-b7d2-1e48ed03f9a0` |
 | 发布状态 | GitHub Pre-release、非 Draft、非 Latest |
 
-> 当前生产版本为 `0.3.6 (Build 2)`。本版只升级稳定单任务 Codex 灵动岛，
-> 新增独立显示开关、“粒子球 / 波澜光晕”实时动画选择，以及完成后缩小和
-> 缩小后隐藏时间控制；不迁入多任务 Preview。正式签名、公证/Staple、
-> GitHub Release/Latest、回下载和公开签名 appcast 均已完成；详细证据见
-> 本文件的 `0.3.6 (Build 2)` 章节。
+> 当前生产版本为 `0.3.7 (Build 1)`。本版完整展示多个有效 Codex 核心额度
+> 窗口，并增加单一“锁定到 Codex 屏幕”开关；不迁入多任务 Preview。
+> 正式签名、公证/Staple、GitHub Release/Latest、回下载和公开签名 appcast
+> 均已完成；详细证据见本文件的 `0.3.7 (Build 1)` 章节。
 
 > 未发布开发版本不在本历史文件登记；当前迭代身份与验证状态只以
 > [HANDOFF.md](HANDOFF.md) 为准，不得把候选版本提前写成已发布。
 
 > “Codex 灵动岛多任务适配”已作为 `0.3.2 Preview 1` 发布，交付状态为
 > `Released`。响应速度、当前任务跟随、任务切换与收展节奏仍是公开已知
-> 不足，因此该版本不晋升为稳定版；其实现不包含在 0.3.6 稳定版中。
+> 不足，因此该版本不晋升为稳定版；其实现不包含在 0.3.7 稳定版中。
 > GitHub Pre-release、tag 和本地归档分支继续保留供社区测试和后续开发
 > 参照。当前状态以
 > [SDD 当前规格](docs/specs/README.md#当前规格) 为准。
@@ -76,8 +75,9 @@
 
 | 版本 | 日期（Asia/Shanghai） | 状态 | 核心定位 |
 |---|---|---|---|
-| `0.3.6 (Build 2)` | 2026-08-23 | **当前最新** | 单任务 Codex 灵动岛动画、显示与事件时间个性化 |
-| `0.3.5 (Build 5)` | 2026-08-11 | 历史正式版 / 0.3.6 回滚基线 | Spark 与 30 日用量概览、半年 Token 活动、Stable 应用更新检查 |
+| `0.3.7 (Build 1)` | 2026-08-26 | **当前最新** | 多周期额度完整展示与灵动岛多屏锁定 |
+| `0.3.6 (Build 2)` | 2026-08-23 | 历史正式版 / 0.3.7 回滚基线 | 单任务 Codex 灵动岛动画、显示与事件时间个性化 |
+| `0.3.5 (Build 5)` | 2026-08-11 | 历史正式版 | Spark 与 30 日用量概览、半年 Token 活动、Stable 应用更新检查 |
 | `0.3.3 (Build 3)` | 2026-08-11 | 历史正式版 | Token 活动统计、单色方格图与顶部固定动态面板 |
 | `0.3.2 (Build 1) Preview 1` | 2026-08-05 | **当前预览版** | Codex 灵动岛多任务支持与可选当前任务跟随 |
 | `0.3.1 (Build 2)` | 2026-08-01 | 历史正式版 / 0.3.3 回滚基线 | Widget 共享容器热修复与可变额度周期文案 |
@@ -90,12 +90,67 @@
 | `0.1.3` | 2026-07-26 | 历史正式版 | 设置、外观、语言、图标和发布流程完善 |
 | `0.1.0` | 2026-07-26 | 首个公开版本 | Codex 额度、Credits、Token 与重置时间基础能力 |
 
+## 0.3.7 (Build 1)
+
+Tag：`v0.3.7-build.1`
+
+状态：当前最新正式 Release、GitHub Latest、非 Draft、非 Pre-release；
+已进入公开 Stable appcast。
+
+发布提交：
+`6f6f30a58141deff45a5b2c67546421cba06ad70`
+
+主要特性：
+
+- 将 Codex `primary` 与 `secondary` 额度窗口独立建模、使用稳定行 ID，并按
+  实际周期从短到长显示；5 小时与周额度可以同时完整呈现；
+- 额度标题由真实 `windowDurationMins` 生成，不根据订阅方案猜测；次窗口
+  缺失或无效时局部隐藏，不伪造 `0%`；
+- Spark 继续作为独立中性额度显示在核心窗口之后，保留自己的用量与重置
+  时间，不重复显示订阅方案；
+- 设置页增加单一“锁定到 Codex 屏幕”开关：开启时跟随最大可见 Codex
+  窗口所在屏幕，关闭时跟随热区；跨屏使用最大交集，不可定位时自动回退；
+- 屏幕定位只读取 Codex PID、可见窗口与显示器几何，不读取标题、内容或
+  像素，不新增辅助功能或屏幕录制权限；
+- 保留稳定单任务灵动岛、粒子球/波澜光晕、收起时间自定义和 Reduce Motion；
+  产品 Build 为 1，Sparkle 内部更新序号为 11。
+
+验证与发布资产：
+
+- `swift test`：72 项通过、0 失败；PR #31 GitHub CI 通过并合并到 `main`；
+- Universal Release 构建通过；App、Widget 与 Activity Hook 均为
+  `x86_64 arm64`；版本为 Marketing `0.3.7`、内部 `11`、产品 Build `1`；
+- 文件名：`QuotaView-v0.3.7-build.1.zip`
+- 大小：`12,927,829 bytes`
+- SHA-256：
+  `42e815cbb12f18112e3423c48f6392232ef25c061cfa9ba96d19012ddaa7b5c4`
+- Developer ID：`Developer ID Application: Chenchen Xu (BUUH229D5Q)`，
+  证书 SHA-1 `E52D0A9C7C377AF77C484155CC0CFCFB27D949D3`，启用
+  Hardened Runtime；
+- Apple 公证：Accepted，已 Staple；Submission
+  `04654ab7-29ea-4bda-a131-3363f58fb840`；
+- GitHub 回下载资产与本地公证包逐字节一致；重新解压后通过嵌套
+  `codesign --deep --strict`、Staple、Gatekeeper、版本、资源与架构复核，
+  本地包和线上回下载包均完成独立启动冒烟；
+- GitHub Release Notes 使用
+  `docs/releases/QuotaView-0.3.7-build.1.md` 的单份英文源文；
+- 公开 Feed：`https://duoasa.github.io/QuotaView/appcast.xml`；`gh-pages`
+  提交 `bcff201229d9ce5499f984c0176c6686b4d29d60`；Feed SHA-256
+  `3e79e1cee579ab87eb84b766374e36de62d9115d4dc75fed22c56b8e1e4a3488`；
+  线上文件与本地签名文件逐字节一致，Feed EdDSA 验证通过；
+- 完整深浅色、跨屏、VoiceOver/Increase Contrast/Reduce Motion 矩阵和真实
+  0.3.6 → 0.3.7 应用内替换重启流程尚未形成独立记录，不由发布事实自动
+  视为通过。
+
+Release：
+[QuotaView 0.3.7 Build 1 — Multiple Quota Windows and a Screen-Aware Codex Island](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.7-build.1)
+
 ## 0.3.6 (Build 2)
 
 Tag：`v0.3.6-build.2`
 
-状态：当前最新正式 Release、GitHub Latest、非 Draft、非 Pre-release；
-已进入公开 Stable appcast。
+状态：历史正式 Release、0.3.7 的封存回滚基线、非 Draft、非 Pre-release；
+已由 0.3.7 Build 1 替代。
 
 发布提交：
 `ab033001a194b78e2ec80f31e1f334ea1cae0021`

--- a/docs/design/quotaview-app-updates-0.3.5.md
+++ b/docs/design/quotaview-app-updates-0.3.5.md
@@ -41,9 +41,9 @@
 - 该批准触发完整链路：合并、Developer ID、公证/Staple、不可变 Stable
   Release、回下载、EdDSA appcast 与文档联动；更换身份或重新打包需重新确认；
 - appcast 可跳过未批准的中间版本；每个后续版本都需独立批准；
-- `0.3.5 Build 5` 与 `0.3.6 Build 2` 已明确获准并完成发布；`0.3.7 Build 1`
-  已于 2026-08-26 获得精确版本准入，发布链执行中。已完成版本的详细资产
-  证据只在 [`VERSION_HISTORY.md`](../../VERSION_HISTORY.md) 保存。
+- `0.3.5 Build 5`、`0.3.6 Build 2` 与 `0.3.7 Build 1` 均已分别明确获准并
+  完成发布；详细资产证据只在
+  [`VERSION_HISTORY.md`](../../VERSION_HISTORY.md) 保存。
 
 ## Requirement
 
@@ -58,6 +58,7 @@
 | `APP-UPDATES-07` | 两个正式版本完成真实客户端 N → N+1 检查、下载、替换与重启 |
 | `APP-UPDATES-08` | 精确版本显式准入；未批准默认排除 |
 
-`APP-UPDATES-01...06/08` 已由 0.3.5 和 0.3.6 发布链验证；尚未从真实 0.3.5
-客户端独立记录到 0.3.6 的完整安装操作，因此 `APP-UPDATES-07` 和本规格
-保持 `Verifying`。这不改变两个版本各自已经 Released 的事实。
+`APP-UPDATES-01...06/08` 已由 0.3.5、0.3.6 和 0.3.7 发布链验证；尚未从
+真实旧版客户端独立记录一次完整 N → N+1 检查、下载、替换与重启，因此
+`APP-UPDATES-07` 和本规格保持 `Verifying`。这不改变各版本已经 Released
+的事实。

--- a/docs/design/quotaview-codex-activity-island-0.3.6.md
+++ b/docs/design/quotaview-codex-activity-island-0.3.6.md
@@ -4,11 +4,11 @@
 >
 > 规格状态：`Accepted`
 >
-> 交付状态：`Verifying`
+> 交付状态：`Released`
 >
-> 当前开发：`0.3.7 Build 1`（Sparkle 内部序号 `11`）
+> 当前生产：`0.3.7 Build 1`（Sparkle 内部序号 `11`）
 >
-> 已发布基线：`0.3.6 Build 2`（Sparkle 内部序号 `7`）
+> 回滚基线：`0.3.6 Build 2`（Sparkle 内部序号 `7`）
 
 本文件合并了 0.3.1 的稳定单任务基础契约与 0.3.6 的个性化升级，是当前
 生产灵动岛的唯一规格。`0.3.2 Preview 1` 多任务实验不属于本规格。
@@ -102,8 +102,9 @@
 不可变资产、签名、公证、Release 和 appcast 证据见
 [`VERSION_HISTORY.md`](../../VERSION_HISTORY.md#036-build-2)。完整生产视觉与
 辅助功能交叉矩阵仍按 [`design-qa.md`](../../design-qa.md) 记录，不由发布
-事实自动推导为通过。0.3.7 Build 1 的屏幕定位实现、72 项测试和 Universal
-无签名 Release 构建已通过，App、Widget 与 Activity Hook 均为
-`x86_64 + arm64`；多屏视觉与交互等待产品所有者验收，尚未签名、发布或
-进入 appcast；该精确版本已获准启动正式签名、公证与发布链，完成前仍保持
-`Verifying`。
+事实自动推导为通过。0.3.7 Build 1 的屏幕定位实现、72 项测试、GitHub CI、
+Universal、Developer ID、公证/Staple、回下载启动冒烟与公开 appcast 均已
+完成，完整证据见
+[`VERSION_HISTORY.md`](../../VERSION_HISTORY.md#037-build-1)。多屏视觉、
+VoiceOver 与完整外观交叉矩阵仍等待产品所有者按需验收，不由 `Released`
+自动推导为全量通过。

--- a/docs/design/quotaview-quota-windows-0.3.6-build.3.md
+++ b/docs/design/quotaview-quota-windows-0.3.6-build.3.md
@@ -4,11 +4,11 @@
 >
 > 规格状态：`Accepted`
 >
-> 交付状态：`Verifying`
+> 交付状态：`Released`
 >
-> 生产基线：`0.3.6 Build 2`
+> 生产版本：`0.3.7 Build 1`
 >
-> 最终发布候选：`0.3.7 Build 1`；Sparkle 内部更新序号 `11`
+> Sparkle 内部更新序号：`11`
 
 ## 决策
 
@@ -60,14 +60,14 @@ Spark 继续作为 `codex_bengalfox` 的独立中性窗口，位于全部 Codex 
 - 核对 App、Widget 的 Marketing Version、内部更新序号和产品 Build；
 - 搜索临时 Mock/UI QA 入口并执行 `git diff --check`；
 - 深浅色、中英文、单/双主窗口、Spark 有无及顶部锚定由产品所有者手动
-  验收，完成前交付状态保持 `Verifying`。
+  验收；未形成完整交叉矩阵时如实保留为未记录，不由发布事实推导为通过。
 
 ## 非目标
 
 - 不修改 OpenAI 限额规则，不承诺某一订阅恒定拥有某个周期；
 - 不扩展 Widget 共享快照为多窗口；
 - 不新增额度窗口显隐开关或手动排序；
-- 本规格不改变既有发布机制；0.3.7 Build 1 是否发布仅由精确版本准入决定。
+- 本规格不改变既有发布机制；任何后续版本仍需独立的精确版本准入。
 
 ## 当前验证记录
 
@@ -75,7 +75,9 @@ Spark 继续作为 `codex_bengalfox` 的独立中性窗口，位于全部 Codex 
   Spark 并存以及短周期优先排序；
 - Universal Xcode Release 无签名构建通过；App、Widget、Activity Hook 与
   Core 均为 `x86_64 arm64`；
-- App 与 Widget 候选身份均为 Marketing Version `0.3.7`、Sparkle 内部序号
+- App 与 Widget 身份均为 Marketing Version `0.3.7`、Sparkle 内部序号
   `11`、产品 Build `1`；`Assets.car`、`AppIcon.icns` 与波澜光晕资源存在；
-- 视觉与交互结果等待产品所有者在真实账户的单/双窗口数据下验收；尚未
-  完整签名发布链执行中。
+- Developer ID、公证/Staple、GitHub Latest、回下载启动冒烟与公开签名
+  appcast 均已完成，完整证据见
+  [`VERSION_HISTORY.md`](../../VERSION_HISTORY.md#037-build-1)；真实账户下
+  的完整深浅色与单/双窗口视觉矩阵仍等待产品所有者按需验收。

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -4,9 +4,9 @@
 >
 > 状态：`Accepted`
 >
-> 生产基线：`0.3.6 Build 2`
+> 生产基线：`0.3.7 Build 1`
 >
-> 当前开发：`0.3.7 Build 1`（Sparkle 内部更新序号 `11`）
+> 当前开发：无；生产 Sparkle 内部更新序号 `11`
 
 本文件只负责规格发现和状态定位，不复制 Requirement、实现或发布证据。
 
@@ -14,8 +14,8 @@
 
 | Spec ID | 文档 | 状态 | 当前结论 |
 |---|---|---|---|
-| `QV-PRODUCT-QUOTA-WINDOWS-003` | [多周期额度展示](../design/quotaview-quota-windows-0.3.6-build.3.md) | `Accepted / Verifying` | 已纳入 0.3.7 Build 1 发布候选并获 Stable appcast 准入 |
-| `QV-PRODUCT-ACTIVITY-ISLAND-004` | [稳定单任务灵动岛](../design/quotaview-codex-activity-island-0.3.6.md) | `Accepted / Verifying` | 0.3.7 Build 1 新增“锁定到 Codex 屏幕”开关；多任务实验不在稳定范围 |
+| `QV-PRODUCT-QUOTA-WINDOWS-003` | [多周期额度展示](../design/quotaview-quota-windows-0.3.6-build.3.md) | `Accepted / Released` | 已随 0.3.7 Build 1 发布并进入 Stable appcast |
+| `QV-PRODUCT-ACTIVITY-ISLAND-004` | [稳定单任务灵动岛](../design/quotaview-codex-activity-island-0.3.6.md) | `Accepted / Released` | “锁定到 Codex 屏幕”已随 0.3.7 Build 1 发布；多任务实验不在稳定范围 |
 | `QV-PRODUCT-APP-UPDATES-003` | [应用检查与更新](../design/quotaview-app-updates-0.3.5.md) | `Accepted / Verifying` | Stable Feed 已发布；真实 N → N+1 安装操作待记录 |
 
 当前版本与下一步见 [Handoff](../../HANDOFF.md)，不可变发布事实见


### PR DESCRIPTION
## Summary
- promote 0.3.7 Build 1 to the documented stable baseline
- record immutable tag, Release asset, SHA-256, Developer ID, notarization, and appcast evidence
- mark quota windows and Codex Island screen placement as Released
- preserve outstanding real in-app N to N+1 and full visual/accessibility matrix work

## Verification
- documentation-only follow-up; no source, resource, configuration, or packaging changes
- release/tag/latest/asset metadata verified against GitHub
- public appcast matches the locally signed feed byte-for-byte and passes EdDSA verification
- git diff --check passed