### PR TITLE
Record QuotaView 0.4.3 release

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -11,10 +11,10 @@
 
 | 项目 | 当前值 |
 |---|---|
-| 稳定版 | `0.4.2 Build 1` / `v0.4.2-build.1` / GitHub Latest |
-| 回滚基线 | `0.4.1 Build 1` / `v0.4.1-build.1` |
+| 稳定版 | `0.4.3 Build 1` / `v0.4.3-build.1` / GitHub Latest |
+| 回滚基线 | `0.4.2 Build 1` / `v0.4.2-build.1` |
 | 公开预览 | `0.3.2 Preview 1`；不属于稳定源码或 Stable appcast |
-| 当前候选 | `0.4.3 Build 1` / Sparkle 内部序号 `15`；发布验证中，尚未成为 GitHub Latest 或 Stable appcast |
+| 当前候选 | 无；0.4.3 已完成正式发布 |
 | 当前主题 | 量子噪点相位、完成态、压缩上下文可见性与粒子不透明度修正；进度条左侧文字采用两级淡灰并增强操作状态流光；完成描边与呼吸光晕统一绿色基准 |
 
 产品可见 Build 在 Marketing Version 变化后归 `1`，同一版本内逐次递增；
@@ -24,8 +24,8 @@ Sparkle `CFBundleVersion` 跨 Marketing Version 单调递增。
 
 | Spec | 状态 | 结论 / 未完成项 |
 |---|---|---|
-| [`QV-RELEASE-0.4.3-001`](docs/design/quotaview-0.4.3-release.md) | `Accepted / Verifying` | 104 项测试已通过；签名、公证、GitHub Release 与 appcast 正在验证 |
-| [`QV-PRODUCT-ACTIVITY-ISLAND-QUANTUM-NOISE-009`](docs/design/quotaview-quantum-noise-effect-correction.md) | `Accepted / Verifying` | 保留 `dropField` 持久化兼容；独立连续相位、增强闪灭及完成态中密度粒子覆盖已通过 104 项测试和 Universal 构建，等待产品所有者视觉验收 |
+| [`QV-RELEASE-0.4.3-001`](docs/design/quotaview-0.4.3-release.md) | `Accepted / Released` | 104 项测试、Universal、Developer ID、公证/Staple、GitHub Latest、回下载启动与 Stable appcast 在线 EdDSA 均已完成 |
+| [`QV-PRODUCT-ACTIVITY-ISLAND-QUANTUM-NOISE-009`](docs/design/quotaview-quantum-noise-effect-correction.md) | `Accepted / Released` | 保留 `dropField` 持久化兼容；连续换色、增强闪灭、压缩上下文与完成反馈已随 0.4.3 发布 |
 | [`QV-RELEASE-0.4.2-001`](docs/design/quotaview-0.4.2-release.md) | `Accepted / Released` | Developer ID、公证/Staple、GitHub Latest、回下载启动和 Stable appcast 在线 EdDSA 均已完成 |
 | [`QV-PRODUCT-ACTIVITY-ISLAND-LIFECYCLE-008`](docs/design/quotaview-activity-island-lifecycle-continuity-0.4.2.md) | `Accepted / Released` | 投递来源、ACK/队列、turn 感知终态锁与生命周期动画门控已实现；完成态只接受真实 `Stop` |
 | [`QV-PRODUCT-ACTIVITY-ISLAND-PROGRESS-EFFECTS-007`](docs/design/quotaview-progress-effects-0.4.2.md) | `Accepted / Released` | 四种真实预览、细密 Drops、清晰 Slosh、状态配色适配和平滑完成反馈已随 0.4.2 发布 |
@@ -35,9 +35,9 @@ Sparkle `CFBundleVersion` 跨 Marketing Version 单调递增。
 | [`QV-PRODUCT-ACTIVITY-ISLAND-SIZE-005`](docs/design/quotaview-codex-activity-island-size-0.4.0.md) | `Accepted / Released` | 100% / 85% / 75% AI 球展开尺寸及进度条固定双语几何已随 0.4.1 Build 1 发布 |
 | [`QV-PRODUCT-QUOTA-WINDOWS-003`](docs/design/quotaview-quota-windows-0.3.6-build.3.md) | `Accepted / Released` | 多周期额度已随 0.3.7 Build 1 发布并进入 Stable Feed |
 | [`QV-PRODUCT-ACTIVITY-ISLAND-004`](docs/design/quotaview-codex-activity-island-0.3.6.md) | `Accepted / Released` | “锁定到 Codex 屏幕”已随 0.3.7 Build 1 发布；不包含多任务 Preview |
-| [`QV-PRODUCT-APP-UPDATES-003`](docs/design/quotaview-app-updates-0.3.5.md) | `Accepted / Verifying` | 0.3.5、0.3.6、0.3.7、0.4.1 与 0.4.2 均已进入 Stable Feed；尚缺一次真实 N → N+1 替换与重启记录 |
+| [`QV-PRODUCT-APP-UPDATES-003`](docs/design/quotaview-app-updates-0.3.5.md) | `Accepted / Verifying` | 0.4.3 已进入 Stable Feed；尚缺一次由旧版客户端发起的真实 N → N+1 替换与重启记录 |
 
-### 2.1 0.4.3 Build 1 候选（2026-09-03）
+### 2.1 0.4.3 Build 1 发布（2026-09-03）
 
 产品所有者已将 2026-08-30 固定的视觉检查点指定为 `0.4.3 Build 1`，
 Sparkle 内部序号从 `14` 单调递增为 `15`，并授权合并 `main`、发布 GitHub
@@ -48,16 +48,26 @@ Release 与更新 Stable appcast。
 sRGB `#00FF11` 的完成描边和呼吸光晕。完整视觉与辅助功能交叉矩阵仍只由
 产品所有者验收，不以自动化测试替代。
 
-完整 `swift test` 已通过 104 项、0 失败。Developer ID 封包、公证、远端
-Release、回下载、启动冒烟与 Stable appcast 在线签名验证尚未完成；这些
-事实只在对应步骤真实完成后写入版本历史。
+PR #40 已合并到 `main`，发布提交为
+`b76c317d640e73621b6e2119e4363d0cac6ddff6`。完整 `swift test` 104 项通过、
+0 失败；Universal、Developer ID、Apple 公证/Staple、GitHub Latest、远端
+资产逐字节回下载、`/Applications` 启动与单一 Widget 注册均已验证。
+
+正式资产 `QuotaView-v0.4.3-build.1.zip` 为 `13,166,345 bytes`，SHA-256
+`a2b35249c3c146444207fc82d041121e790d099cc534b597775262e42160d54c`；
+公证 Submission 为 `e3f5f0fa-8f36-4ed3-8b26-3b6ef1861344`。Stable appcast
+由 `gh-pages` 提交 `56c02c07cebfbeb19a2684ee3dff2bce2f6bbe0c` 发布，
+线上 SHA-256 为
+`2e5b058592c5b823511391e54a4d873c962d787f54899c1dc1e9da034a9eb40a`，
+逐字节与 EdDSA 验证通过。完整视觉与辅助功能交叉矩阵未单独记录为全量
+通过。
 
 ## 3. 长期边界
 
 - 后续版本必须由产品所有者针对精确版本重新批准，不能沿用 0.4.3 的
   appcast 准入；
-- `0.4.2 Build 1` 是当前正式 Release、GitHub Latest 与 Stable appcast
-  条目；`0.4.1 Build 1` 是封存回滚基线，0.4.0 不创建公开 Release；
+- `0.4.3 Build 1` 是当前正式 Release、GitHub Latest 与 Stable appcast
+  条目；`0.4.2 Build 1` 是封存回滚基线，0.4.0 不创建公开 Release；
 - GitHub push、tag 或 Release 默认不进入自动更新序列；
 - 稳定版只保留单任务灵动岛。多任务 Preview 的 tag、Release 和归档分支
   `codex/archive-0.3.2-preview.1-multitask-island` 仅供历史参考；
@@ -65,14 +75,13 @@ Release、回下载、启动冒烟与 Stable appcast 在线签名验证尚未完
 
 ## 4. 下一步
 
-1. 完成 0.4.3 的测试、合并、Developer ID 封包、公证、GitHub Release、
-   回下载启动和 Stable appcast 在线验证；
-2. 只有在线事实完成后，才能把 0.4.3 写成稳定版并更新版本历史；
-3. 如需关闭更新器规格的 `APP-UPDATES-07`，使用正式旧版客户端完成一次
+1. 下一次迭代从 `0.4.3 Build 1` 稳定基线建立新的精确规格，不复用已发布
+   候选身份；
+2. 如需关闭更新器规格的 `APP-UPDATES-07`，使用正式旧版客户端完成一次
    到 0.4.3 的真实应用内检查、下载、替换与重启；
-4. 完整深浅色、多屏、VoiceOver、Increase Contrast 与 Reduce Motion 矩阵
+3. 完整深浅色、多屏、VoiceOver、Increase Contrast 与 Reduce Motion 矩阵
    仍由产品所有者按需验收；
-5. 新任务从 [SDD 注册表](docs/specs/README.md) 只读取对应的一份当前规格。
+4. 新任务从 [SDD 注册表](docs/specs/README.md) 只读取对应的一份当前规格。
 
 ## 5. 文档入口
 

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -15,29 +15,29 @@
 
 | 项目 | 当前值 |
 |---|---|
-| 最新推荐版本 | `0.4.2 (Build 1)` |
-| Git tag | `v0.4.2-build.1` |
-| Tag commit | `6c8434950d59afd9439b2f6f50d8c8b091a40f6d` |
-| GitHub Release | [QuotaView 0.4.2 Build 1 — More Progress Styles, Steadier Activity](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.2-build.1) |
-| Release 资产 | `QuotaView-v0.4.2-build.1.zip` |
-| 资产大小 | `13,166,133 bytes` |
-| SHA-256 | `a87f7f03da644fb014a8c90b617b99697bbb6aae72a7c35928d3386bbf2c05a3` |
+| 最新推荐版本 | `0.4.3 (Build 1)` |
+| Git tag | `v0.4.3-build.1` |
+| Tag commit | `b76c317d640e73621b6e2119e4363d0cac6ddff6` |
+| GitHub Release | [QuotaView 0.4.3 Build 1 — Clearer Progress Feedback](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.3-build.1) |
+| Release 资产 | `QuotaView-v0.4.3-build.1.zip` |
+| 资产大小 | `13,166,345 bytes` |
+| SHA-256 | `a2b35249c3c146444207fc82d041121e790d099cc534b597775262e42160d54c` |
 | 最低系统版本 | macOS 14 |
 | 架构 | Universal `arm64 + x86_64` |
 | 签名 | `Developer ID Application: Chenchen Xu (BUUH229D5Q)`，证书 SHA-1 `E52D0A9C7C377AF77C484155CC0CFCFB27D949D3`，启用 Hardened Runtime |
-| 公证 | Apple Accepted，已 Staple；Submission `5cad0ca0-7f2e-49ef-beda-34b151ed2f45` |
+| 公证 | Apple Accepted，已 Staple；Submission `e3f5f0fa-8f36-4ed3-8b26-3b6ef1861344` |
 | 发布状态 | 正式 Release、Latest、非 Draft、非 Pre-release |
-| 自动更新 Feed | [公开 appcast](https://duoasa.github.io/QuotaView/appcast.xml)；`gh-pages` 提交 `ead810f540261fbd3e67d17f0f0d32401606b0c0`；Feed SHA-256 `a8ddb8809340caed56dbf0743ab71f51bb2bae6a1a8a067676853cfd76185e8b`；线上文件逐字节一致且 EdDSA 验证通过 |
+| 自动更新 Feed | [公开 appcast](https://duoasa.github.io/QuotaView/appcast.xml)；`gh-pages` 提交 `56c02c07cebfbeb19a2684ee3dff2bce2f6bbe0c`；Feed SHA-256 `2e5b058592c5b823511391e54a4d873c962d787f54899c1dc1e9da034a9eb40a`；线上文件逐字节一致且 EdDSA 验证通过 |
 
 上一稳定回滚基线：
 
 | 项目 | 封存值 |
 |---|---|
-| 版本 | `0.4.1 (Build 1)` |
-| tag / commit | `v0.4.1-build.1` / `e14039eeb7021041f384b10db386a80844694b0f` |
-| Release | [QuotaView 0.4.1 Build 1 — A Progress-Aware Codex Island](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.1-build.1) |
-| 资产 / SHA-256 | `QuotaView-v0.4.1-build.1.zip` / `ae8cf53acc6e6473ebf33bb853b7448672b48c4e849ef4b219efd74b18a9a2a3` |
-| 状态 | 不可移动历史正式版；发生 0.4.2 回滚时使用该 tag 与已核验资产 |
+| 版本 | `0.4.2 (Build 1)` |
+| tag / commit | `v0.4.2-build.1` / `6c8434950d59afd9439b2f6f50d8c8b091a40f6d` |
+| Release | [QuotaView 0.4.2 Build 1 — More Progress Styles, Steadier Activity](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.2-build.1) |
+| 资产 / SHA-256 | `QuotaView-v0.4.2-build.1.zip` / `a87f7f03da644fb014a8c90b617b99697bbb6aae72a7c35928d3386bbf2c05a3` |
+| 状态 | 不可移动历史正式版；发生 0.4.3 回滚时使用该 tag 与已核验资产 |
 
 当前公开预览版：
 
@@ -56,18 +56,18 @@
 | 公证 | Apple Accepted，已 Staple；Submission `47c6d413-465f-4632-b7d2-1e48ed03f9a0` |
 | 发布状态 | GitHub Pre-release、非 Draft、非 Latest |
 
-> 当前生产版本为 `0.4.2 (Build 1)`。本版增加四种进度条效果与真实设置
-> 预览，并修正多步骤任务中的误隐藏、提前完成和空闲动画；不迁入多任务
-> Preview。
+> 当前生产版本为 `0.4.3 (Build 1)`。本版让量子噪点换色保持连续相位，
+> 增强压缩上下文、闪灭与完成段可见性，并统一文字层级和完成绿色辉光；
+> 不迁入多任务 Preview。
 > 正式签名、公证/Staple、GitHub Release/Latest、回下载和公开签名 appcast
-> 均已完成；详细证据见本文件的 `0.4.2 (Build 1)` 章节。
+> 均已完成；详细证据见本文件的 `0.4.3 (Build 1)` 章节。
 
 > 未发布开发版本不在本历史文件登记；当前迭代身份与验证状态只以
 > [HANDOFF.md](HANDOFF.md) 为准，不得把候选版本提前写成已发布。
 
 > “Codex 灵动岛多任务适配”已作为 `0.3.2 Preview 1` 发布，交付状态为
 > `Released`。响应速度、当前任务跟随、任务切换与收展节奏仍是公开已知
-> 不足，因此该版本不晋升为稳定版；其实现不包含在 0.4.2 稳定版中。
+> 不足，因此该版本不晋升为稳定版；其实现不包含在 0.4.3 稳定版中。
 > GitHub Pre-release、tag 和本地归档分支继续保留供社区测试和后续开发
 > 参照。当前状态以
 > [SDD 当前规格](docs/specs/README.md#当前规格) 为准。
@@ -76,8 +76,9 @@
 
 | 版本 | 日期（Asia/Shanghai） | 状态 | 核心定位 |
 |---|---|---|---|
-| `0.4.2 (Build 1)` | 2026-08-30 | **当前最新** | 四种进度效果、真实设置预览与可靠的任务连续性 |
-| `0.4.1 (Build 1)` | 2026-08-30 | 历史正式版 / 0.4.2 回滚基线 | 独立进度条灵动岛、近似进度、AI 球三档尺寸与完成高光 |
+| `0.4.3 (Build 1)` | 2026-09-03 | **当前最新** | 量子噪点连续换色、更清晰的文字与统一完成辉光 |
+| `0.4.2 (Build 1)` | 2026-08-30 | 历史正式版 / 0.4.3 回滚基线 | 四种进度效果、真实设置预览与可靠的任务连续性 |
+| `0.4.1 (Build 1)` | 2026-08-30 | 历史正式版 | 独立进度条灵动岛、近似进度、AI 球三档尺寸与完成高光 |
 | `0.3.7 (Build 1)` | 2026-08-26 | 历史正式版 | 多周期额度完整展示与灵动岛多屏锁定 |
 | `0.3.6 (Build 2)` | 2026-08-23 | 历史正式版 | 单任务 Codex 灵动岛动画、显示与事件时间个性化 |
 | `0.3.5 (Build 5)` | 2026-08-11 | 历史正式版 | Spark 与 30 日用量概览、半年 Token 活动、Stable 应用更新检查 |
@@ -93,12 +94,61 @@
 | `0.1.3` | 2026-07-26 | 历史正式版 | 设置、外观、语言、图标和发布流程完善 |
 | `0.1.0` | 2026-07-26 | 首个公开版本 | Codex 额度、Credits、Token 与重置时间基础能力 |
 
+## 0.4.3 (Build 1)
+
+Tag：`v0.4.3-build.1`
+
+状态：当前最新正式 Release、GitHub Latest、非 Draft、非 Pre-release；
+已进入公开 Stable appcast。
+
+发布提交：
+`b76c317d640e73621b6e2119e4363d0cac6ddff6`
+
+主要特性：
+
+- 量子噪点在 Codex 状态换色时保持独立连续相位，不再产生纵向跳动；
+- 提高压缩上下文灰白可见性、星点闪灭与粒子不透明度，并让更多中密度
+  粒子参与克制的完成高亮；
+- 标题与操作状态使用两级不透明淡灰，保留更清晰的状态流光；
+- 完成描边与呼吸光晕统一使用 sRGB `#00FF11`，呼吸只改变外部半径；
+- Product Build 为 1，Sparkle 内部更新序号为 15。
+
+验证与发布资产：
+
+- `swift test`：104 项通过、0 失败；PR #40 GitHub CI 通过并合并到 `main`；
+- Universal Release 构建通过；App、Widget 与 Activity Hook 均为
+  `x86_64 arm64`；版本为 Marketing `0.4.3`、内部 `15`、产品 Build `1`；
+- 文件名：`QuotaView-v0.4.3-build.1.zip`
+- 大小：`13,166,345 bytes`
+- SHA-256：
+  `a2b35249c3c146444207fc82d041121e790d099cc534b597775262e42160d54c`
+- Developer ID：`Developer ID Application: Chenchen Xu (BUUH229D5Q)`，
+  证书 SHA-1 `E52D0A9C7C377AF77C484155CC0CFCFB27D949D3`，启用
+  Hardened Runtime；
+- Apple 公证：Accepted，已 Staple；Submission
+  `e3f5f0fa-8f36-4ed3-8b26-3b6ef1861344`；
+- GitHub 回下载资产与本地公证包逐字节一致；重新解压后通过嵌套
+  `codesign --deep --strict`、Staple、Gatekeeper、版本、资源与三目标双架构
+  复核，并从 `/Applications/QuotaView.app` 完成启动冒烟；WidgetKit 只保留
+  一个 0.4.3 扩展注册；
+- GitHub Release Notes 使用
+  `docs/releases/QuotaView-0.4.3-build.1.md` 的单份简洁英文源文；
+- 公开 Feed：`https://duoasa.github.io/QuotaView/appcast.xml`；`gh-pages`
+  提交 `56c02c07cebfbeb19a2684ee3dff2bce2f6bbe0c`；Feed SHA-256
+  `2e5b058592c5b823511391e54a4d873c962d787f54899c1dc1e9da034a9eb40a`；
+  线上文件与本地签名文件逐字节一致，Feed EdDSA 验证通过；
+- 产品所有者已批准当前结果发布；完整深浅色、多屏、VoiceOver、Increase
+  Contrast 与 Reduce Motion 交叉矩阵未单独记录为全量通过。
+
+Release：
+[QuotaView 0.4.3 Build 1 — Clearer Progress Feedback](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.3-build.1)
+
 ## 0.4.2 (Build 1)
 
 Tag：`v0.4.2-build.1`
 
-状态：当前最新正式 Release、GitHub Latest、非 Draft、非 Pre-release；
-已进入公开 Stable appcast。
+状态：历史正式 Release、0.4.3 的封存回滚基线、非 Draft、非 Pre-release；
+已由 0.4.3 Build 1 替代并继续保留在公开 Stable appcast。
 
 发布提交：
 `6c8434950d59afd9439b2f6f50d8c8b091a40f6d`

--- a/docs/design/quotaview-0.4.3-release.md
+++ b/docs/design/quotaview-0.4.3-release.md
@@ -2,7 +2,7 @@
 
 > Spec ID：`QV-RELEASE-0.4.3-001`
 >
-> 状态：`Accepted / Verifying`
+> 状态：`Accepted / Released`
 >
 > 日期：2026-09-03
 >
@@ -41,9 +41,20 @@
 | `RELEASE-0.4.3-05` | Stable appcast 使用 Sparkle EdDSA 签名并在线验证；GitHub 回下载资产与本地公证包逐字节一致 |
 | `RELEASE-0.4.3-06` | `HANDOFF.md`、`VERSION_HISTORY.md`、SDD 注册表和功能规格只在对应线上事实完成后标记 `Released` |
 
-## 当前状态
+## 发布结果
 
-- 产品所有者已指定 `0.4.3 Build 1` 并授权 GitHub、Release 与 appcast 发布；
-- 候选版本、文档与发布说明正在准备；
-- 完整 `swift test` 104 项通过、0 失败；签名、公证、远端合并、Release 和
-  appcast 证据尚待完成。
+- PR #40 GitHub CI 通过并合并到 `main`；发布提交为
+  `b76c317d640e73621b6e2119e4363d0cac6ddff6`；
+- 完整 `swift test` 104 项通过、0 失败；Universal App、Widget 与 Activity
+  Hook 均为 `x86_64 arm64`；
+- Developer ID 与 Hardened Runtime 验证通过；Apple 公证 Accepted 并完成
+  Staple，Submission `e3f5f0fa-8f36-4ed3-8b26-3b6ef1861344`；
+- 正式资产 `QuotaView-v0.4.3-build.1.zip` 为 `13,166,345 bytes`，SHA-256
+  `a2b35249c3c146444207fc82d041121e790d099cc534b597775262e42160d54c`；
+- GitHub Release 为 Latest、非 Draft、非 Pre-release；回下载文件与本地
+  公证包逐字节一致，并从 `/Applications/QuotaView.app` 完成启动冒烟；
+- Stable appcast 由 `gh-pages` 提交
+  `56c02c07cebfbeb19a2684ee3dff2bce2f6bbe0c` 发布，线上 SHA-256 为
+  `2e5b058592c5b823511391e54a4d873c962d787f54899c1dc1e9da034a9eb40a`，
+  逐字节与 Sparkle EdDSA 验证通过；
+- 完整视觉与辅助功能交叉矩阵仍由产品所有者按需验收。

--- a/docs/design/quotaview-app-updates-0.3.5.md
+++ b/docs/design/quotaview-app-updates-0.3.5.md
@@ -41,7 +41,8 @@
 - 该批准触发完整链路：合并、Developer ID、公证/Staple、不可变 Stable
   Release、回下载、EdDSA appcast 与文档联动；更换身份或重新打包需重新确认；
 - appcast 可跳过未批准的中间版本；每个后续版本都需独立批准；
-- `0.3.5 Build 5`、`0.3.6 Build 2` 与 `0.3.7 Build 1` 均已分别明确获准并
+- `0.3.5 Build 5`、`0.3.6 Build 2`、`0.3.7 Build 1`、`0.4.1 Build 1`、
+  `0.4.2 Build 1` 与 `0.4.3 Build 1` 均已分别明确获准并
   完成发布；详细资产证据只在
   [`VERSION_HISTORY.md`](../../VERSION_HISTORY.md) 保存。
 

--- a/docs/design/quotaview-quantum-noise-effect-correction.md
+++ b/docs/design/quotaview-quantum-noise-effect-correction.md
@@ -2,7 +2,7 @@
 
 > Spec ID：`QV-PRODUCT-ACTIVITY-ISLAND-QUANTUM-NOISE-009`
 >
-> 状态：`Accepted / Verifying`
+> 状态：`Accepted / Released`
 >
 > 日期：2026-08-30
 >
@@ -41,7 +41,7 @@
 - 不改变近似进度算法、Hook 事件、完成真相或隐藏时机；
 - 不改变 `stateSmoke`、`diamondFront`、`sloshFlow` 的运动语言；
 - 不建立新纹理、网络读取、文件读取或新的持久化字段；
-- 本轮不封包、不发布、不更新 appcast。
+- 实现阶段不自行封包或发布；只有产品所有者指定精确版本并批准后进入发布链。
 
 ## 验证
 
@@ -98,7 +98,9 @@
 - 量子噪点保留既有闪灭曲线并将粒子不透明度提高 `10%`、峰值钳制为
   `1.0`；生产渲染契约定向冒烟测试 1 项通过、0 失败，Universal Release
   无签名构建通过；
-- 2026-08-30 按产品所有者要求冻结为未指定发布版本的本地检查点；最终视觉
-  微调后未重跑完整测试，继续保留各项定向冒烟与 Universal 构建证据；
-- 尚未封包、签名、公证、推送、创建 tag 或修改 appcast；颜色换色稳定性、闪灭强度、
-  完成亮度与高亮粒子覆盖率等待产品所有者手动验收。
+- 2026-09-03 定版前重跑完整 `swift test`：104 项通过、0 失败；PR #40 CI
+  通过并合并到 `main`；
+- 已随 `0.4.3 Build 1` / 内部序号 `15` 发布；Developer ID、公证/Staple、
+  GitHub Latest、回下载启动与 Stable appcast 在线 EdDSA 均已完成；
+- 完整深浅色、多屏、VoiceOver、Increase Contrast 与 Reduce Motion 交叉
+  矩阵仍等待产品所有者按需验收。

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -4,9 +4,9 @@
 >
 > 状态：`Accepted`
 >
-> 生产基线：`0.4.2 Build 1`
+> 生产基线：`0.4.3 Build 1`
 >
-> 当前候选：`0.4.3 Build 1` / Sparkle 内部更新序号 `15`；正在发布验证
+> 当前候选：无
 
 本文件只负责规格发现和状态定位，不复制 Requirement、实现或发布证据。
 
@@ -14,8 +14,8 @@
 
 | Spec ID | 文档 | 状态 | 当前结论 |
 |---|---|---|---|
-| `QV-RELEASE-0.4.3-001` | [0.4.3 Build 1 发布](../design/quotaview-0.4.3-release.md) | `Accepted / Verifying` | 104 项测试已通过；签名、公证、GitHub Release 与 appcast 正在验证 |
-| `QV-PRODUCT-ACTIVITY-ISLAND-QUANTUM-NOISE-009` | [量子噪点效果修正](../design/quotaview-quantum-noise-effect-correction.md) | `Accepted / Verifying` | 本地候选已冻结；主体改造曾通过 104 项测试，最终视觉微调通过对应定向冒烟与 Universal 构建，完整视觉矩阵仍待验收 |
+| `QV-RELEASE-0.4.3-001` | [0.4.3 Build 1 发布](../design/quotaview-0.4.3-release.md) | `Accepted / Released` | 104 项测试、Universal、Developer ID、公证/Staple、GitHub Latest、回下载启动与 Stable appcast 在线 EdDSA 均已完成 |
+| `QV-PRODUCT-ACTIVITY-ISLAND-QUANTUM-NOISE-009` | [量子噪点效果修正](../design/quotaview-quantum-noise-effect-correction.md) | `Accepted / Released` | 连续相位、压缩上下文可见性、闪灭、文字层级与完成反馈已随 0.4.3 发布；完整视觉矩阵仍待验收 |
 | `QV-RELEASE-0.4.2-001` | [0.4.2 Build 1 发布](../design/quotaview-0.4.2-release.md) | `Accepted / Released` | 103 项测试、Universal、Developer ID、公证/Staple、GitHub Latest、回下载启动与 Stable appcast 在线 EdDSA 均已完成 |
 | `QV-PRODUCT-ACTIVITY-ISLAND-LIFECYCLE-008` | [0.4.2 任务连续性修正](../design/quotaview-activity-island-lifecycle-continuity-0.4.2.md) | `Accepted / Released` | 实时事件不再因局部步骤结束而误隐藏或提前完成；完成态只接受真实 `Stop`，已随 0.4.2 发布 |
 | `QV-PRODUCT-ACTIVITY-ISLAND-PROGRESS-EFFECTS-007` | [0.4.2 进度条效果库](../design/quotaview-progress-effects-0.4.2.md) | `Accepted / Released` | 四种真实预览、状态配色适配、平滑进度与三个新增效果的完成高亮已随 0.4.2 发布 |


### PR DESCRIPTION
## Summary
- mark 0.4.3 Build 1 as the latest stable release
- record immutable tag, asset, notarization, installation, and appcast evidence
- synchronize Handoff and the SDD registry

## Validation
- documentation-only follow-up
- git diff --check
- release and latest metadata verified remotely
- downloaded ZIP and online appcast verified byte-for-byte and cryptographically