### PR TITLE
docs: record QuotaView 0.4.5 release

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -11,10 +11,10 @@
 
 | 项目 | 当前值 |
 |---|---|
-| 稳定版 | `0.4.3 Build 1` / `v0.4.3-build.1` / GitHub Latest |
-| 回滚基线 | `0.4.2 Build 1` / `v0.4.2-build.1` |
+| 稳定版 | `0.4.5 Build 1` / `v0.4.5-build.1` / GitHub Latest |
+| 回滚基线 | `0.4.3 Build 1` / `v0.4.3-build.1` |
 | 公开预览 | `0.3.2 Preview 1`；不属于稳定源码或 Stable appcast |
-| 当前候选 | `0.4.5 Build 1` / Sparkle 内部 Build `17`；产品所有者已批准，正在发布 |
+| 当前候选 | 无；`0.4.5 Build 1` 已正式发布 |
 | 当前主题 | 只读本地任务流主通道，Socket/Hook 回退；灵动岛显示本次 turn Token 与完成额度回执，悬停进入 80% 透明态，等待确认满 10 秒后显示黄色描边和光晕 |
 
 产品可见 Build 在 Marketing Version 变化后归 `1`，同一版本内逐次递增；
@@ -24,11 +24,11 @@ Sparkle `CFBundleVersion` 跨 Marketing Version 单调递增。
 
 | Spec | 状态 | 结论 / 未完成项 |
 |---|---|---|
-| [`QV-RELEASE-0.4.5-001`](docs/design/quotaview-0.4.5-release.md) | `Accepted / Publishing` | 产品所有者已批准；README、产品图、Developer ID、公证、GitHub Latest 与 Stable appcast 正在执行 |
-| [`QV-PRODUCT-ACTIVITY-ISLAND-CONFIRMATION-REMINDER-014`](docs/design/quotaview-activity-island-confirmation-reminder-0.4.5.md) | `Accepted / Publishing` | 真实等待确认持续满 10 秒后显示静态黄色描边与四周黄色光晕；两次 25 秒状态链通过，产品所有者已批准发布 |
-| [`QV-PRODUCT-ACTIVITY-ISLAND-TURN-TOKENS-013`](docs/design/quotaview-activity-island-turn-token-usage-0.4.5.md) | `Accepted / Publishing` | rollout 主通道的运行态实时 Token、真实成功终态左右回执、当前额度与紧凑额度环已实现；产品所有者已批准发布 |
-| [`QV-PRODUCT-ACTIVITY-ISLAND-HOVER-TRANSPARENCY-012`](docs/design/quotaview-activity-island-hover-transparency-0.4.5.md) | `Accepted / Publishing` | 悬停时整个灵动岛保留 20% 可见度且继续点击穿透；产品所有者已批准发布 |
-| [`QV-PRODUCT-CODEX-SOCKET-AUTOCONNECT-011`](docs/design/quotaview-codex-socket-autoconnect-0.4.5.md) | `Accepted / Publishing` | 只读本地任务流主通道、共享 Socket/Hook 回退及真实四步计划已验证；产品所有者已批准发布 |
+| [`QV-RELEASE-0.4.5-001`](docs/design/quotaview-0.4.5-release.md) | `Accepted / Released` | 130 项测试、Universal Developer ID、公证/Staple、GitHub Latest、回下载验证与 Stable appcast 在线 EdDSA 均已完成 |
+| [`QV-PRODUCT-ACTIVITY-ISLAND-CONFIRMATION-REMINDER-014`](docs/design/quotaview-activity-island-confirmation-reminder-0.4.5.md) | `Accepted / Released` | 真实等待确认持续满 10 秒后显示静态黄色描边与四周黄色光晕；已随 0.4.5 发布 |
+| [`QV-PRODUCT-ACTIVITY-ISLAND-TURN-TOKENS-013`](docs/design/quotaview-activity-island-turn-token-usage-0.4.5.md) | `Accepted / Released` | rollout 主通道的实时 Token、真实成功终态左右回执、当前额度与紧凑额度环已随 0.4.5 发布 |
+| [`QV-PRODUCT-ACTIVITY-ISLAND-HOVER-TRANSPARENCY-012`](docs/design/quotaview-activity-island-hover-transparency-0.4.5.md) | `Accepted / Released` | 悬停时整个灵动岛保留 20% 可见度且继续点击穿透；已随 0.4.5 发布 |
+| [`QV-PRODUCT-CODEX-SOCKET-AUTOCONNECT-011`](docs/design/quotaview-codex-socket-autoconnect-0.4.5.md) | `Accepted / Released` | 只读本地任务流主通道、共享 Socket/Hook 回退及真实四步计划已验证并随 0.4.5 发布 |
 | [`QV-PRODUCT-ACTIVITY-ISLAND-CODEX-PLAN-010`](docs/design/quotaview-codex-plan-compatibility-0.4.4.md) | `Accepted / Superseded` | 0.4.4 未发布；原生计划、Goal、等待、真实终态和共享桥成果已由 0.4.5 继承 |
 | [`QV-RELEASE-0.4.3-001`](docs/design/quotaview-0.4.3-release.md) | `Accepted / Released` | 104 项测试、Universal、Developer ID、公证/Staple、GitHub Latest、回下载启动与 Stable appcast 在线 EdDSA 均已完成 |
 | [`QV-PRODUCT-ACTIVITY-ISLAND-QUANTUM-NOISE-009`](docs/design/quotaview-quantum-noise-effect-correction.md) | `Accepted / Released` | 保留 `dropField` 持久化兼容；连续换色、增强闪灭、压缩上下文与完成反馈已随 0.4.3 发布 |
@@ -41,9 +41,9 @@ Sparkle `CFBundleVersion` 跨 Marketing Version 单调递增。
 | [`QV-PRODUCT-ACTIVITY-ISLAND-SIZE-005`](docs/design/quotaview-codex-activity-island-size-0.4.0.md) | `Superseded / Released` | 0.4.1 已发布的 AI 球尺寸能力作为历史保留；0.4.5 已移除 AI 球及其展开尺寸选择器 |
 | [`QV-PRODUCT-QUOTA-WINDOWS-003`](docs/design/quotaview-quota-windows-0.3.6-build.3.md) | `Accepted / Released` | 多周期额度已随 0.3.7 Build 1 发布并进入 Stable Feed |
 | [`QV-PRODUCT-ACTIVITY-ISLAND-004`](docs/design/quotaview-codex-activity-island-0.3.6.md) | `Accepted / Released` | “锁定到 Codex 屏幕”已随 0.3.7 Build 1 发布；不包含多任务 Preview |
-| [`QV-PRODUCT-APP-UPDATES-003`](docs/design/quotaview-app-updates-0.3.5.md) | `Accepted / Verifying` | 0.4.3 已进入 Stable Feed；尚缺一次由旧版客户端发起的真实 N → N+1 替换与重启记录 |
+| [`QV-PRODUCT-APP-UPDATES-003`](docs/design/quotaview-app-updates-0.3.5.md) | `Accepted / Verifying` | 0.4.5 已进入 Stable Feed；尚缺一次由旧版客户端发起的真实 N → N+1 替换与重启记录 |
 
-### 2.1 0.4.5 Build 1 开发候选（2026-09-04）
+### 2.1 0.4.5 Build 1 发布（2026-09-04）
 
 0.4.5 在 0.4.4 未发布候选上继续开发；当前分支已提升为
 `codex/0.4.5-development`，物理工作树目录保留原名以保护连续的未提交工作。
@@ -107,10 +107,22 @@ Reduce Motion 下两者保持静态。完成态仍独占紫蓝青反馈，不与
 Build、资源和干净临时副本的 ad-hoc 严格校验通过。开发 ZIP SHA-256 为
 `fc247a259f9f25f6f405bccbd5308ad1582667ff7bfa55ec34a77c635c99c297`。
 新干净副本以 PID `80828` 启动；只读额度探针确认主数据可用，已用 `52%`、
-剩余 `48%`。产品所有者已检查关键视觉路径并批准发布。Developer ID、公证、
-GitHub Release、Stable appcast 与最终远端回读由
-[`QV-RELEASE-0.4.5-001`](docs/design/quotaview-0.4.5-release.md) 继续执行；完整
-交互与辅助功能交叉矩阵不作为本次发布的已验证结论。
+剩余 `48%`。产品所有者已检查关键视觉路径并批准发布。
+
+PR #42 的 GitHub CI 通过后已合并到 `main`；发布提交与 tag commit 为
+`75913c07e4457b5f6451f286522799d36982ff0c`。正式资产
+`QuotaView-v0.4.5-build.1.zip` 为 `13,477,643 bytes`，SHA-256 为
+`d5308880d9dc096e46cdbf715db414ae79a4bc92a1dcc4f433d315a6a7bd7e5a`。
+Developer ID 与 Hardened Runtime 有效；Apple 公证 Accepted 并已 Staple，
+Submission 为 `67ae8361-068b-4adf-aecf-de2f2b174e07`。GitHub Release 已设为
+Latest、非 Draft、非 Pre-release；回下载资产与本地公证包逐字节一致，并在
+宿主环境通过嵌套签名、Staple、Gatekeeper、版本、资源和四目标双架构复核。
+
+Stable appcast 已由 `gh-pages` 提交
+`9fc9745a9464f42d890c119a13dabf87896d09a5` 发布；线上 Feed SHA-256 为
+`d4e1d5a218742b743c04305c3ab29e27bbfaece1f0f4b7d7ab788b16bb6a3b01`，
+与本地签名文件逐字节一致且 EdDSA 验证通过。完整交互与辅助功能交叉矩阵
+不作为本次发布的已验证结论。
 
 ### 2.2 0.4.4 Build 1 未发布候选（2026-09-03）
 
@@ -173,10 +185,10 @@ PR #40 已合并到 `main`，发布提交为
 
 ## 3. 长期边界
 
-- 后续版本必须由产品所有者针对精确版本重新批准，不能沿用 0.4.3 的
+- 后续版本必须由产品所有者针对精确版本重新批准，不能沿用 0.4.5 的
   appcast 准入；
-- `0.4.3 Build 1` 是当前正式 Release、GitHub Latest 与 Stable appcast
-  条目；`0.4.2 Build 1` 是封存回滚基线，0.4.0 不创建公开 Release；
+- `0.4.5 Build 1` 是当前正式 Release、GitHub Latest 与 Stable appcast
+  条目；`0.4.3 Build 1` 是封存回滚基线，0.4.0 不创建公开 Release；
 - GitHub push、tag 或 Release 默认不进入自动更新序列；
 - 稳定版只保留单任务灵动岛。多任务 Preview 的 tag、Release 和归档分支
   `codex/archive-0.3.2-preview.1-multitask-island` 仅供历史参考；
@@ -184,12 +196,9 @@ PR #40 已合并到 `main`，发布提交为
 
 ## 4. 下一步
 
-1. 完成 0.4.5 Developer ID 构建、Apple 公证/Staple、GitHub Latest、回下载
-   验证与 Stable appcast 在线 EdDSA 核验；
-2. 远端事实完成后同步 `VERSION_HISTORY.md`、本 Handoff、SDD 注册表和相关
-   功能规格，不能提前写入最终提交、资产散列或 Submission；
-3. 更新器规格的 `APP-UPDATES-07` 保持独立待办，不影响本次发布；
-4. 完整深浅色、多屏、VoiceOver、Increase Contrast 与 Reduce Motion 矩阵
+1. 更新器规格的 `APP-UPDATES-07` 保持独立待办，后续记录一次由旧版客户端
+   发起的真实 N → N+1 替换与重启；
+2. 完整深浅色、多屏、VoiceOver、Increase Contrast 与 Reduce Motion 矩阵
    仍由产品所有者按需补充，不记录为本次全量通过。
 
 ## 5. 文档入口

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -15,29 +15,29 @@
 
 | 项目 | 当前值 |
 |---|---|
-| 最新推荐版本 | `0.4.3 (Build 1)` |
-| Git tag | `v0.4.3-build.1` |
-| Tag commit | `b76c317d640e73621b6e2119e4363d0cac6ddff6` |
-| GitHub Release | [QuotaView 0.4.3 Build 1 — Clearer Progress Feedback](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.3-build.1) |
-| Release 资产 | `QuotaView-v0.4.3-build.1.zip` |
-| 资产大小 | `13,166,345 bytes` |
-| SHA-256 | `a2b35249c3c146444207fc82d041121e790d099cc534b597775262e42160d54c` |
+| 最新推荐版本 | `0.4.5 (Build 1)` |
+| Git tag | `v0.4.5-build.1` |
+| Tag commit | `75913c07e4457b5f6451f286522799d36982ff0c` |
+| GitHub Release | [QuotaView 0.4.5 Build 1 — Native Codex Activity Bridge](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.5-build.1) |
+| Release 资产 | `QuotaView-v0.4.5-build.1.zip` |
+| 资产大小 | `13,477,643 bytes` |
+| SHA-256 | `d5308880d9dc096e46cdbf715db414ae79a4bc92a1dcc4f433d315a6a7bd7e5a` |
 | 最低系统版本 | macOS 14 |
 | 架构 | Universal `arm64 + x86_64` |
 | 签名 | `Developer ID Application: Chenchen Xu (BUUH229D5Q)`，证书 SHA-1 `E52D0A9C7C377AF77C484155CC0CFCFB27D949D3`，启用 Hardened Runtime |
-| 公证 | Apple Accepted，已 Staple；Submission `e3f5f0fa-8f36-4ed3-8b26-3b6ef1861344` |
+| 公证 | Apple Accepted，已 Staple；Submission `67ae8361-068b-4adf-aecf-de2f2b174e07` |
 | 发布状态 | 正式 Release、Latest、非 Draft、非 Pre-release |
-| 自动更新 Feed | [公开 appcast](https://duoasa.github.io/QuotaView/appcast.xml)；`gh-pages` 提交 `56c02c07cebfbeb19a2684ee3dff2bce2f6bbe0c`；Feed SHA-256 `2e5b058592c5b823511391e54a4d873c962d787f54899c1dc1e9da034a9eb40a`；线上文件逐字节一致且 EdDSA 验证通过 |
+| 自动更新 Feed | [公开 appcast](https://duoasa.github.io/QuotaView/appcast.xml)；`gh-pages` 提交 `9fc9745a9464f42d890c119a13dabf87896d09a5`；Feed SHA-256 `d4e1d5a218742b743c04305c3ab29e27bbfaece1f0f4b7d7ab788b16bb6a3b01`；线上文件逐字节一致且 EdDSA 验证通过 |
 
 上一稳定回滚基线：
 
 | 项目 | 封存值 |
 |---|---|
-| 版本 | `0.4.2 (Build 1)` |
-| tag / commit | `v0.4.2-build.1` / `6c8434950d59afd9439b2f6f50d8c8b091a40f6d` |
-| Release | [QuotaView 0.4.2 Build 1 — More Progress Styles, Steadier Activity](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.2-build.1) |
-| 资产 / SHA-256 | `QuotaView-v0.4.2-build.1.zip` / `a87f7f03da644fb014a8c90b617b99697bbb6aae72a7c35928d3386bbf2c05a3` |
-| 状态 | 不可移动历史正式版；发生 0.4.3 回滚时使用该 tag 与已核验资产 |
+| 版本 | `0.4.3 (Build 1)` |
+| tag / commit | `v0.4.3-build.1` / `b76c317d640e73621b6e2119e4363d0cac6ddff6` |
+| Release | [QuotaView 0.4.3 Build 1 — Clearer Progress Feedback](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.3-build.1) |
+| 资产 / SHA-256 | `QuotaView-v0.4.3-build.1.zip` / `a2b35249c3c146444207fc82d041121e790d099cc534b597775262e42160d54c` |
+| 状态 | 不可移动历史正式版；发生 0.4.5 回滚时使用该 tag 与已核验资产 |
 
 当前公开预览版：
 
@@ -56,11 +56,11 @@
 | 公证 | Apple Accepted，已 Staple；Submission `47c6d413-465f-4632-b7d2-1e48ed03f9a0` |
 | 发布状态 | GitHub Pre-release、非 Draft、非 Latest |
 
-> 当前生产版本为 `0.4.3 (Build 1)`。本版让量子噪点换色保持连续相位，
-> 增强压缩上下文、闪灭与完成段可见性，并统一文字层级和完成绿色辉光；
-> 不迁入多任务 Preview。
+> 当前生产版本为 `0.4.5 (Build 1)`。本版增加只读本地任务流数据桥，新版
+> Codex 即开即用、无需 Hook 首次配置，并升级状态灵动岛的实时 Token、
+> 完成额度回执、悬停透明和长时间等待确认提醒；不迁入多任务 Preview。
 > 正式签名、公证/Staple、GitHub Release/Latest、回下载和公开签名 appcast
-> 均已完成；详细证据见本文件的 `0.4.3 (Build 1)` 章节。
+> 均已完成；详细证据见本文件的 `0.4.5 (Build 1)` 章节。
 
 > 未发布开发版本不在本历史文件登记；当前迭代身份与验证状态只以
 > [HANDOFF.md](HANDOFF.md) 为准，不得把候选版本提前写成已发布。
@@ -76,8 +76,9 @@
 
 | 版本 | 日期（Asia/Shanghai） | 状态 | 核心定位 |
 |---|---|---|---|
-| `0.4.3 (Build 1)` | 2026-09-03 | **当前最新** | 量子噪点连续换色、更清晰的文字与统一完成辉光 |
-| `0.4.2 (Build 1)` | 2026-08-30 | 历史正式版 / 0.4.3 回滚基线 | 四种进度效果、真实设置预览与可靠的任务连续性 |
+| `0.4.5 (Build 1)` | 2026-09-04 | **当前最新** | 只读本地任务流数据桥、无需 Hook 的开箱连接与状态灵动岛升级 |
+| `0.4.3 (Build 1)` | 2026-09-03 | 历史正式版 / 0.4.5 回滚基线 | 量子噪点连续换色、更清晰的文字与统一完成辉光 |
+| `0.4.2 (Build 1)` | 2026-08-30 | 历史正式版 | 四种进度效果、真实设置预览与可靠的任务连续性 |
 | `0.4.1 (Build 1)` | 2026-08-30 | 历史正式版 | 独立进度条灵动岛、近似进度、AI 球三档尺寸与完成高光 |
 | `0.3.7 (Build 1)` | 2026-08-26 | 历史正式版 | 多周期额度完整展示与灵动岛多屏锁定 |
 | `0.3.6 (Build 2)` | 2026-08-23 | 历史正式版 | 单任务 Codex 灵动岛动画、显示与事件时间个性化 |
@@ -94,12 +95,68 @@
 | `0.1.3` | 2026-07-26 | 历史正式版 | 设置、外观、语言、图标和发布流程完善 |
 | `0.1.0` | 2026-07-26 | 首个公开版本 | Codex 额度、Credits、Token 与重置时间基础能力 |
 
+## 0.4.5 (Build 1)
+
+Tag：`v0.4.5-build.1`
+
+状态：当前最新正式 Release、GitHub Latest、非 Draft、非 Pre-release；
+已进入公开 Stable appcast。
+
+发布提交：
+`75913c07e4457b5f6451f286522799d36982ff0c`
+
+主要特性：
+
+- 新增只读本地任务流数据桥，直接跟随 Codex Desktop 的 rollout；新版
+  Codex 首次安装即可自动连接，无需安装或确认 Activity Hook；
+- 数据源按本地任务流、共享 App Server、legacy Hook 降级；只投影任务
+  生命周期、计划状态计数、Token 数值、工具类别、工作区末级名称和哈希标识，
+  不保存提示词、回复、推理、命令、工具输入输出、diff 或完成正文；
+- 灵动岛统一为进度条形态并默认使用量子噪点，移除 AI 球及其动画和尺寸
+  选择器；已有合法进度效果偏好继续生效；
+- 运行态实时显示本次 turn Token；真实成功终态显示左右完成回执和当前额度
+  剩余百分比，紧凑态显示同心风险色额度环；
+- 悬停时整个灵动岛进入 80% 透明态并保持点击穿透；等待确认满 10 秒后显示
+  静态黄色描边和四周黄色光晕；完成态保留紫蓝青固定描边和外部辉光；
+- Product Build 为 1，Sparkle 内部更新序号为 17。
+
+验证与发布资产：
+
+- `swift test`：130 项通过、0 失败；PR #42 GitHub CI 通过并合并到 `main`；
+- Universal Developer ID Release 构建通过；App、Core、Widget 与 Activity
+  Hook 均为 `x86_64 arm64`；版本为 Marketing `0.4.5`、内部 `17`、产品
+  Build `1`；
+- 文件名：`QuotaView-v0.4.5-build.1.zip`
+- 大小：`13,477,643 bytes`
+- SHA-256：
+  `d5308880d9dc096e46cdbf715db414ae79a4bc92a1dcc4f433d315a6a7bd7e5a`
+- Developer ID：`Developer ID Application: Chenchen Xu (BUUH229D5Q)`，
+  证书 SHA-1 `E52D0A9C7C377AF77C484155CC0CFCFB27D949D3`，启用
+  Hardened Runtime；
+- Apple 公证：Accepted，已 Staple；Submission
+  `67ae8361-068b-4adf-aecf-de2f2b174e07`；
+- GitHub 回下载资产与本地公证包逐字节一致；重新解压后在宿主环境通过嵌套
+  `codesign --deep --strict`、Staple、Gatekeeper、版本、资源与四目标双架构
+  复核；
+- GitHub Release Notes 使用
+  `docs/releases/QuotaView-0.4.5-build.1.md` 的单份英文源文；中英文 README
+  使用 `Resources/QuotaView-0.4.5-Activity-Bridge.png` 介绍本版；
+- 公开 Feed：`https://duoasa.github.io/QuotaView/appcast.xml`；`gh-pages`
+  提交 `9fc9745a9464f42d890c119a13dabf87896d09a5`；Feed SHA-256
+  `d4e1d5a218742b743c04305c3ab29e27bbfaece1f0f4b7d7ab788b16bb6a3b01`；
+  线上文件与本地签名文件逐字节一致，Feed EdDSA 验证通过；
+- 产品所有者已检查关键视觉路径并批准发布；完整深浅色、多屏、VoiceOver、
+  Increase Contrast 与 Reduce Motion 交叉矩阵未单独记录为全量通过。
+
+Release：
+[QuotaView 0.4.5 Build 1 — Native Codex Activity Bridge](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.5-build.1)
+
 ## 0.4.3 (Build 1)
 
 Tag：`v0.4.3-build.1`
 
-状态：当前最新正式 Release、GitHub Latest、非 Draft、非 Pre-release；
-已进入公开 Stable appcast。
+状态：历史正式 Release、0.4.5 的封存回滚基线、非 Draft、非 Pre-release；
+已由 0.4.5 Build 1 替代并继续保留在公开 Stable appcast。
 
 发布提交：
 `b76c317d640e73621b6e2119e4363d0cac6ddff6`

--- a/docs/design/quotaview-0.4.5-release.md
+++ b/docs/design/quotaview-0.4.5-release.md
@@ -2,7 +2,7 @@
 
 > Spec ID：`QV-RELEASE-0.4.5-001`
 >
-> 状态：`Accepted / Publishing`
+> 状态：`Accepted / Released`
 >
 > 日期：2026-09-04
 >
@@ -46,8 +46,25 @@
 ## 当前状态
 
 - 产品所有者已批准 0.4.5 Build 1 发布；
-- 开发验证为 `swift test` 130 项通过、0 失败，Universal 无签名构建、
-  ad-hoc 严格签名校验和干净副本启动通过；
-- Developer ID、公证、Release、回下载与 Stable appcast 正在执行；
-- 完整发布事实将在远端验证完成后写回本规格、`VERSION_HISTORY.md` 与
-  `HANDOFF.md`。
+- `swift test` 130 项通过、0 失败；PR #42 CI 通过并合并到 `main`，发布提交
+  与 tag commit 为 `75913c07e4457b5f6451f286522799d36982ff0c`；
+- Universal Developer ID Release 构建通过；App、Core、Widget 与 Activity
+  Hook 均为 `x86_64 arm64`，版本为 Marketing `0.4.5`、内部 `17`、产品
+  Build `1`；
+- 正式资产 `QuotaView-v0.4.5-build.1.zip` 为 `13,477,643 bytes`，SHA-256
+  `d5308880d9dc096e46cdbf715db414ae79a4bc92a1dcc4f433d315a6a7bd7e5a`；
+- Developer ID 证书 SHA-1 为
+  `E52D0A9C7C377AF77C484155CC0CFCFB27D949D3`，Apple 公证 Accepted 并已
+  Staple；Submission `67ae8361-068b-4adf-aecf-de2f2b174e07`；
+- GitHub Release 已发布为 Latest、非 Draft、非 Pre-release；回下载资产与
+  本地公证包逐字节一致，并在宿主环境通过嵌套签名、Staple、Gatekeeper、
+  版本、资源与四目标双架构复核；
+- 中英文 README 已使用 `Resources/QuotaView-0.4.5-Activity-Bridge.png`，
+  下载入口指向正式资产；Release Notes 以
+  `docs/releases/QuotaView-0.4.5-build.1.md` 为单份英文源文；
+- Stable appcast 由 `gh-pages` 提交
+  `9fc9745a9464f42d890c119a13dabf87896d09a5` 发布，线上 Feed SHA-256 为
+  `d4e1d5a218742b743c04305c3ab29e27bbfaece1f0f4b7d7ab788b16bb6a3b01`；
+  线上文件与本地签名文件逐字节一致且 EdDSA 验证通过；
+- 完整深浅色、多屏、VoiceOver、Increase Contrast 与 Reduce Motion 交叉
+  矩阵未单独记录为全量通过。

--- a/docs/design/quotaview-activity-island-confirmation-reminder-0.4.5.md
+++ b/docs/design/quotaview-activity-island-confirmation-reminder-0.4.5.md
@@ -2,7 +2,7 @@
 
 > Spec ID：`QV-PRODUCT-ACTIVITY-ISLAND-CONFIRMATION-REMINDER-014`
 >
-> 状态：`Accepted / Publishing`
+> 状态：`Accepted / Released`
 >
 > 目标版本：`0.4.5 Build 1`（Sparkle 内部 Build `17`）
 
@@ -55,3 +55,4 @@ Codex 任务进入真实“等待确认”或“等待用户输入”状态后�
   门槛，随后切换运行态并以 `Stop` 自然结束；对应事件被正式状态机接收。
 - 产品所有者已批准包含本提醒效果的 0.4.5 候选发布；完整 Reduce Motion 与
   辅助功能交叉矩阵不作为本次发布的已验证结论。
+- 本规格已随 `v0.4.5-build.1` 正式发布。

--- a/docs/design/quotaview-activity-island-hover-transparency-0.4.5.md
+++ b/docs/design/quotaview-activity-island-hover-transparency-0.4.5.md
@@ -2,7 +2,7 @@
 
 > Spec ID：`QV-PRODUCT-ACTIVITY-ISLAND-HOVER-TRANSPARENCY-012`
 >
-> 状态：`Accepted / Publishing`
+> 状态：`Accepted / Released`
 >
 > 目标版本：`0.4.5 Build 1`（Sparkle 内部 Build `17`）
 
@@ -53,5 +53,6 @@
 - 开发 ZIP `dist/QuotaView-v0.4.5-build.1.zip` 的 SHA-256 为
   `fc247a259f9f25f6f405bccbd5308ad1582667ff7bfa55ec34a77c635c99c297`。
 - 量子噪点进度条及真实分步计划对应关系已由产品所有者完成视觉确认；产品
-  所有者已批准包含本规格在内的 0.4.5 候选发布。完整交互与辅助功能交叉矩阵
-  不作为本次发布的已验证结论。
+  所有者已批准包含本规格在内的 0.4.5 候选发布；本规格已随
+  `v0.4.5-build.1` 正式发布。完整交互与辅助功能交叉矩阵不作为本次发布的
+  已验证结论。

--- a/docs/design/quotaview-activity-island-turn-token-usage-0.4.5.md
+++ b/docs/design/quotaview-activity-island-turn-token-usage-0.4.5.md
@@ -2,7 +2,7 @@
 
 > Spec ID：`QV-PRODUCT-ACTIVITY-ISLAND-TURN-TOKENS-013`
 >
-> 状态：`Accepted / Publishing`
+> 状态：`Accepted / Released`
 >
 > 目标版本：`0.4.5 Build 1`（Sparkle 内部 Build `17`）
 
@@ -81,5 +81,5 @@ JSON，但只把允许的数值、枚举、工作区末级名称和哈希标识�
 - 宿主权限额度探针同时确认主数据可用：`Pro 5x` 协议值 `prolite`，已用
   `52%`、剩余 `48%`；该真实主周期快照现已接入完成态右栏和紧凑额度环。
 - 产品所有者已检查运行态与完成态视觉，并批准包含实时 Token、左右布局、
-  额度环和紫蓝青完成效果的 0.4.5 候选发布；Developer ID、公证、GitHub
-  Release 与 Stable appcast 由发布规格继续执行。
+  额度环和紫蓝青完成效果的 0.4.5 候选发布；本规格已随
+  `v0.4.5-build.1` 正式发布。

--- a/docs/design/quotaview-codex-socket-autoconnect-0.4.5.md
+++ b/docs/design/quotaview-codex-socket-autoconnect-0.4.5.md
@@ -2,7 +2,7 @@
 
 > Spec ID：`QV-PRODUCT-CODEX-SOCKET-AUTOCONNECT-011`
 >
-> 状态：`Accepted / Publishing`
+> 状态：`Accepted / Released`
 >
 > 目标版本：`0.4.5 Build 1`（Sparkle 内部 Build `17`）
 
@@ -15,7 +15,7 @@ Desktop 是否连接共享 App Server Socket。共享 Socket 与 Hook/本地队�
 
 本轮从未发布的 0.4.4 共享桥候选继续演进，发布基线为
 `0.4.3 Build 1`。产品所有者已完成关键路径检查并批准 0.4.5 发布；正式
-签名、公证、GitHub Release 与 Stable appcast 由 0.4.5 发布规格统一收口。
+签名、公证、GitHub Release 与 Stable appcast 已由 0.4.5 发布规格收口。
 
 ## 2. 目标与非目标
 
@@ -125,3 +125,4 @@ rollout 不可用 -> Socket/Hook 继续保留兼容能力
 - 通过共享 App Server 的真实四步计划、量子噪点进度条、运行与完成信息、
   等待确认提醒等关键路径已由产品所有者检查并批准发布；完整辅助功能交叉矩阵
   不作为本次发布的已验证结论。
+- 本规格已随 `v0.4.5-build.1` 正式发布。

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -4,9 +4,9 @@
 >
 > 状态：`Accepted`
 >
-> 生产基线：`0.4.3 Build 1`
+> 生产基线：`0.4.5 Build 1`
 >
-> 当前候选：`0.4.5 Build 1`（已批准，正在发布）
+> 当前候选：无
 
 本文件只负责规格发现和状态定位，不复制 Requirement、实现或发布证据。
 
@@ -14,11 +14,11 @@
 
 | Spec ID | 文档 | 状态 | 当前结论 |
 |---|---|---|---|
-| `QV-RELEASE-0.4.5-001` | [0.4.5 Build 1 发布](../design/quotaview-0.4.5-release.md) | `Accepted / Publishing` | 产品所有者已批准；README、产品图、Developer ID、公证、GitHub Latest 与 Stable appcast 正在执行 |
-| `QV-PRODUCT-ACTIVITY-ISLAND-CONFIRMATION-REMINDER-014` | [0.4.5 灵动岛等待确认提醒](../design/quotaview-activity-island-confirmation-reminder-0.4.5.md) | `Accepted / Publishing` | 等待确认满 10 秒显示静态黄色描边和四周光晕；两次 25 秒状态链通过，产品所有者已批准发布 |
-| `QV-PRODUCT-ACTIVITY-ISLAND-TURN-TOKENS-013` | [0.4.5 灵动岛本次任务 Token](../design/quotaview-activity-island-turn-token-usage-0.4.5.md) | `Accepted / Publishing` | rollout 主通道显示实时 turn Token 与成功完成回执；产品所有者已批准发布 |
-| `QV-PRODUCT-ACTIVITY-ISLAND-HOVER-TRANSPARENCY-012` | [0.4.5 灵动岛悬停透明](../design/quotaview-activity-island-hover-transparency-0.4.5.md) | `Accepted / Publishing` | 悬停时整个灵动岛进入 80% 透明态并保持点击穿透；产品所有者已批准发布 |
-| `QV-PRODUCT-CODEX-SOCKET-AUTOCONNECT-011` | [0.4.5 Codex 本地任务流自动连接](../design/quotaview-codex-socket-autoconnect-0.4.5.md) | `Accepted / Publishing` | 只读本地任务流主通道、共享 Socket/Hook 回退及量子噪点单一灵动岛已验证；产品所有者已批准发布 |
+| `QV-RELEASE-0.4.5-001` | [0.4.5 Build 1 发布](../design/quotaview-0.4.5-release.md) | `Accepted / Released` | 130 项测试、Universal Developer ID、公证/Staple、GitHub Latest、回下载验证与 Stable appcast 在线 EdDSA 均已完成 |
+| `QV-PRODUCT-ACTIVITY-ISLAND-CONFIRMATION-REMINDER-014` | [0.4.5 灵动岛等待确认提醒](../design/quotaview-activity-island-confirmation-reminder-0.4.5.md) | `Accepted / Released` | 等待确认满 10 秒显示静态黄色描边和四周光晕；已随 0.4.5 发布 |
+| `QV-PRODUCT-ACTIVITY-ISLAND-TURN-TOKENS-013` | [0.4.5 灵动岛本次任务 Token](../design/quotaview-activity-island-turn-token-usage-0.4.5.md) | `Accepted / Released` | rollout 主通道显示实时 turn Token 与成功完成回执；已随 0.4.5 发布 |
+| `QV-PRODUCT-ACTIVITY-ISLAND-HOVER-TRANSPARENCY-012` | [0.4.5 灵动岛悬停透明](../design/quotaview-activity-island-hover-transparency-0.4.5.md) | `Accepted / Released` | 悬停时整个灵动岛进入 80% 透明态并保持点击穿透；已随 0.4.5 发布 |
+| `QV-PRODUCT-CODEX-SOCKET-AUTOCONNECT-011` | [0.4.5 Codex 本地任务流自动连接](../design/quotaview-codex-socket-autoconnect-0.4.5.md) | `Accepted / Released` | 只读本地任务流主通道、共享 Socket/Hook 回退及量子噪点单一灵动岛已随 0.4.5 发布 |
 | `QV-RELEASE-0.4.3-001` | [0.4.3 Build 1 发布](../design/quotaview-0.4.3-release.md) | `Accepted / Released` | 104 项测试、Universal、Developer ID、公证/Staple、GitHub Latest、回下载启动与 Stable appcast 在线 EdDSA 均已完成 |
 | `QV-PRODUCT-ACTIVITY-ISLAND-QUANTUM-NOISE-009` | [量子噪点效果修正](../design/quotaview-quantum-noise-effect-correction.md) | `Accepted / Released` | 连续相位、压缩上下文可见性、闪灭、文字层级与完成反馈已随 0.4.3 发布；完整视觉矩阵仍待验收 |
 | `QV-RELEASE-0.4.2-001` | [0.4.2 Build 1 发布](../design/quotaview-0.4.2-release.md) | `Accepted / Released` | 103 项测试、Universal、Developer ID、公证/Staple、GitHub Latest、回下载启动与 Stable appcast 在线 EdDSA 均已完成 |
@@ -29,7 +29,7 @@
 | `QV-PRODUCT-ACTIVITY-ISLAND-SIZE-005` | [灵动岛展开尺寸](../design/quotaview-codex-activity-island-size-0.4.0.md) | `Superseded / Released` | 0.4.1 的 AI 球尺寸能力保留为发布历史；0.4.5 已移除 AI 球及其展开尺寸选择器 |
 | `QV-PRODUCT-QUOTA-WINDOWS-003` | [多周期额度展示](../design/quotaview-quota-windows-0.3.6-build.3.md) | `Accepted / Released` | 已随 0.3.7 Build 1 发布并进入 Stable appcast |
 | `QV-PRODUCT-ACTIVITY-ISLAND-004` | [稳定单任务灵动岛](../design/quotaview-codex-activity-island-0.3.6.md) | `Accepted / Released` | “锁定到 Codex 屏幕”已随 0.3.7 Build 1 发布；多任务实验不在稳定范围 |
-| `QV-PRODUCT-APP-UPDATES-003` | [应用检查与更新](../design/quotaview-app-updates-0.3.5.md) | `Accepted / Verifying` | Stable Feed 已发布；真实 N → N+1 安装操作待记录 |
+| `QV-PRODUCT-APP-UPDATES-003` | [应用检查与更新](../design/quotaview-app-updates-0.3.5.md) | `Accepted / Verifying` | 0.4.5 已进入 Stable Feed；真实 N → N+1 安装操作待记录 |
 
 ## 已替代的当前迭代规格
 


### PR DESCRIPTION
## Summary

Records the completed QuotaView 0.4.5 Build 1 publication after the GitHub Release, downloaded-asset verification, and signed Stable appcast were completed.

## Specification

- Spec ID: `QV-RELEASE-0.4.5-001`
- Spec state: `Accepted`
- Delivery state: `Released`
- Spec impact: `Updated` — release facts and related 0.4.5 feature specs now match production.

## Scope

- In scope: version history, Handoff, SDD registry, and 0.4.5 release/feature statuses.
- Explicitly out of scope: production code, resources, configuration, release assets, tags, or appcast content.
- Production behavior before/after: unchanged; this is a Markdown-only release-record update.

## Verification

- [x] `git diff --check`
- [x] Markdown-only change; the release PR already passed 130 Swift tests and GitHub CI.
- [x] GitHub Latest, tag, asset size/SHA-256, Developer ID, notarization/Staple, downloaded artifact, and online appcast were read back before recording them.
- [x] No temporary runtime mocks, auto-click, auto-expand, screenshot, or UI-QA paths were added.
- [x] Product-owner visual acceptance remains distinct from the unrecorded full accessibility matrix.

## Compatibility and privacy

No runtime change. Existing read-only local task-stream and fallback privacy boundaries are only documented.

## Release impact

Records the already-published `v0.4.5-build.1` release as the stable baseline and `v0.4.3-build.1` as the immutable rollback baseline.