### PR TITLE
Document 0.4.6 Build 2 release and update feed

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -11,10 +11,10 @@
 
 | 项目 | 当前值 |
 |---|---|
-| 稳定版 | `0.4.6 Build 1` / internal `18` / `v0.4.6-build.1` / GitHub Latest |
-| 回滚基线 | `0.4.5 Build 1` / `v0.4.5-build.1` |
+| 稳定版 | `0.4.6 Build 2` / internal `19` / `v0.4.6-build.2` / GitHub Latest |
+| 回滚基线 | `0.4.6 Build 1` / `v0.4.6-build.1` |
 | 公开预览 | `0.3.2 Preview 1`；不属于稳定源码或 Stable appcast |
-| 当前候选 | `0.4.6 Build 2` / internal `19`；用户已验收并授权 GitHub 与 appcast 热更新发布，发布验证中 |
+| 当前候选 | 无；Build 2 已正式发布并进入 Stable appcast |
 | 当前主题 | Build 2 迁入新版量子噪点，保留 Build 1 的真实任务生命周期与近似进度算法 |
 
 产品可见 Build 在 Marketing Version 变化后归 `1`，同一版本内逐次递增；
@@ -34,42 +34,32 @@ Sparkle `CFBundleVersion` 跨 Marketing Version 单调递增。
 
 ## 2. 当前规格与状态
 
-### 0.4.6 Build 2 本地候选（2026-09-06）
+### 0.4.6 Build 2 发布完成（2026-09-06）
 
-最新局部试调：用户已确认真实 Codex 上下文压缩时的聚簇动效效果不错，
-随后要求“思考中”保留原配色、复用该运动方式。现仅将思考态运动配置映射到
-压缩态，星点参数、着色、其他状态与真实数据链路保持原实现。
-177 项测试与 Universal Release 构建通过；本次本地验收应用位于
-`/private/tmp/QuotaView-0.4.6-build.2-thinking/QuotaView.app`，
-下述 ZIP 为此前候选，不包含本次思考态调整。用户已验收当前效果并明确授权
-作为 Build 1 的热更新发布 GitHub 与 appcast；将从本次提交重新构建正式包。
+用户已验收真实上下文压缩与蓝紫色思考聚簇，并明确授权作为 Build 1 的热更新
+发布 GitHub、appcast 与 Apple 公证。当前生产保留原版颗粒，增强状态运动、
+配色与低进度渐隐；真实任务生命周期、近似进度来源和其他特效保持原实现。
 
-用户明确授权迁入新版量子噪点、构建、冒烟测试并启动。已接入生产
-`CodexActivityStateSmoke.swift`，保留 `dropField` 设置兼容、真实状态与
-近似进度来源、原生完成时序、Reduce Motion 及其他三种效果。
-生产源码无控制台、模拟数据或手动进度注入。
-
-- `swift test`：177 项通过（既有 166 项 + 11 项生产量子动效检查）。
-- Universal Xcode Release 无签名构建通过；App、Widget、Hook 均为
-  `x86_64 arm64`；App/Widget 为 `0.4.6` / internal `19` / display `2`。
-- AppIcon.icns、Assets.car 齐全。本地 Developer ID / Hardened Runtime
-  签名，运行副本与 ZIP 解压副本的 `codesign --verify --deep --strict` 通过。
-- 本地包 `dist/QuotaView-v0.4.6-build.2-local.zip`，13,547,756 bytes，SHA-256
-  `040d7562be191fda291ced334232a1f90bc0a4d44ddee36d07dd49e1217a1997`。
-- 已启动 `/private/tmp/QuotaView-0.4.6-build.2/QuotaView.app`，运行路径已核对，
-  原生灵动岛已读取真实 Codex 任务。生产视觉与交互等待用户检查。
-- 用户随后报告效果闪回，进程核对发现 Applications 中的 Build 1 仍并行运行。
-  已退出旧实例并核对仅 Build 2 主应用在运行；先前启动检查只匹配候选路径，
-  未排除同 bundle ID 旧实例，是本轮验收疏漏。闪回是否消失等待用户复核。
-- 本地验收包未公证、未发布、未加入 appcast；公开稳定版仍为 Build 1。
-  未提交或推送。本地签名复核需与签名时相同权限，受限沙盒可能误报失败。
+- [Release](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.2) / `v0.4.6-build.2` / 提交 `ae9f17d415fb1968d9ef843be771b6a5211213c7`。
+- App / Widget：`0.4.6` / 产品 `2` / internal `19`；本地与 CI 177 项测试通过，Universal Release 通过。
+- `QuotaView-v0.4.6-build.2.zip`，13,487,447 bytes，SHA-256 `5037b6318284364edd6ae7e26d4a1c4409b9ed182a425047af2af8f751f4f916`。
+- Developer ID / Hardened Runtime；Apple Accepted / Staple，Submission
+  `f466177a-2fea-4e61-9c11-1e405ed32bde`；最终包、解压及回下载严格签名和 Gatekeeper 通过。
+- [公开 appcast](https://duoasa.github.io/QuotaView/appcast.xml) 已更新；提交 `94ae0ec0d63d4a50f77ba3a836afc98d2cb1009d`，
+  SHA-256 `de8c07cc356ebf5d0c813a8e3fbd97703e879343a839a38fc30419bd4a118dce`；线上与本地一致，Feed / ZIP 内置公钥签名验证通过。
+- 回下载包启动通过，运行于 `/private/tmp/quotaview-build2-public-download/extracted/QuotaView.app`；
+  已退出旧验收实例并核对仅一份主应用运行，避免此前双实例视觉闪回。
+- 完整发布证据及 Build 1 回滚入口见 [版本历史](VERSION_HISTORY.md#当前最新版本)。
+- 剩余验证：完整外观/语言/辅助功能矩阵，以及由旧客户端实际执行的 N → N+1 安装。
 
 ### 控制台迭代历史
 
+以下保留各阶段当时的结论；最终生产效果已按上文验收并发布。独立控制台仅在本地保留。
+
 当前独立实验：[量子噪点 Demo 控制台](docs/design/quotaview-quantum-motion-console.md)，
 位于 `Prototypes/QuantumNoiseConsole`。复用 0.4.6 原生岛体进行原版 / 候选
-运动对照；仅手动 DEBUG 数据，不连接真实活动桥。等待用户视觉与交互验收，
-公开资产仍为 Build 1；用户现已授权将当前量子噪点迁入 Build 2 本地候选。
+运动对照；仅手动 DEBUG 数据，不连接真实活动桥。最终选定的生产动效
+已迁入 Build 2 并发布；控制台代码未包含在生产提交中。
 
 全部候选状态与过渡已按临时规范重做，采用全高离散星点；压缩通过局部
 重排表达。最新调整缩小星点、增强彩色状态，并将执行态改为单个轮廓起伏、
@@ -97,10 +87,11 @@ Sparkle `CFBundleVersion` 跨 Marketing Version 单调递增。
 当前开发台的临时验收约束：全高覆盖上下沿，以及清晰离散、明灭闪烁的
 点点星光；禁止整体缩成中央横带或糊成光团/光圈。仅适用于
 `Prototypes/QuantumNoiseConsole`，不作为项目通用或生产设计规范。
-当前实现已按约束重做，等待用户验收。
+控制台阶段的历史验证见规格；当前生产验收以上文为准。
 
 | Spec | 状态 | 结论 / 未完成项 |
 |---|---|---|
+| [`QV-PROTOTYPE-QUANTUM-MOTION-016`](docs/design/quotaview-quantum-motion-console.md) | `Accepted / Released` | 当前效果已获用户验收；177 项本地及 CI 测试、Universal、公证、回下载与 appcast 已验证，Build 2 正式发布 |
 | [`QV-FIX-CODEX-TOKEN-COMPATIBILITY-015`](docs/design/quotaview-codex-token-compatibility-0.4.6.md) | `Accepted / Released` | 本地及 CI 166 项测试、Universal、真实五步视觉通过；PR #45 已合并，签名、公证、Latest、回下载与公开 appcast 验证完成 |
 | [`QV-RELEASE-0.4.5-001`](docs/design/quotaview-0.4.5-release.md) | `Accepted / Released` | 130 项测试、Universal Developer ID、公证/Staple、GitHub Latest、回下载验证与 Stable appcast 在线 EdDSA 均已完成 |
 | [`QV-PRODUCT-ACTIVITY-ISLAND-CONFIRMATION-REMINDER-014`](docs/design/quotaview-activity-island-confirmation-reminder-0.4.5.md) | `Accepted / Released` | 真实等待确认持续满 10 秒后显示静态黄色描边与四周黄色光晕；已随 0.4.5 发布 |
@@ -124,7 +115,7 @@ Sparkle `CFBundleVersion` 跨 Marketing Version 单调递增。
 ### 2.0 0.4.6 Build 1 发布（2026-09-05）
 
 - tag `v0.4.6-build.1`，发布提交 `2b071bea2f0af6fc4de042cf25084fc8524133d9`；
-  [GitHub Release](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.1) 为 Latest。
+  [GitHub Release](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.1) 发布时为 Latest，现为 Build 2 回滚基线。
 - ZIP `QuotaView-v0.4.6-build.1.zip`：`13,564,435 bytes`；SHA-256
   `00bf1a23d4424de534538871e667681ee7f27b5e475a7052e34d73cc06548174`。
 - Developer ID `Chenchen Xu (BUUH229D5Q)`、Hardened Runtime；Apple Accepted
@@ -279,10 +270,9 @@ PR #40 已合并到 `main`，发布提交为
 
 ## 3. 长期边界
 
-- 后续版本必须由产品所有者针对精确版本重新批准，不能沿用 0.4.5 的
+- 后续版本必须由产品所有者针对精确版本重新批准，不能沿用 Build 2 的
   appcast 准入；
-- `0.4.5 Build 1` 是当前正式 Release、GitHub Latest 与 Stable appcast
-  条目；`0.4.3 Build 1` 是封存回滚基线，0.4.0 不创建公开 Release；
+- 当前稳定版与回滚基线以本文第 1 节及版本历史为准；历史 tag 和资产不可覆盖；
 - GitHub push、tag 或 Release 默认不进入自动更新序列；
 - 稳定版只保留单任务灵动岛。多任务 Preview 的 tag、Release 和归档分支
   `codex/archive-0.3.2-preview.1-multitask-island` 仅供历史参考；
@@ -290,7 +280,7 @@ PR #40 已合并到 `main`，发布提交为
 
 ## 4. 下一步
 
-0.4.6 代码与自动化验证已完成，下一步由用户运行候选验收；以下旧待办仍独立保留。
+0.4.6 Build 2 已完成当前效果验收与正式热更新发布；下一轮按用户新反馈迭代，以下待办独立保留。
 
 1. 更新器规格的 `APP-UPDATES-07` 保持独立待办，后续记录一次由旧版客户端
    发起的真实 N → N+1 替换与重启；

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.1"><img alt="Latest release" src="https://img.shields.io/github/v/release/Duoasa/QuotaView?display_name=tag"></a>
+  <a href="https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.2"><img alt="Latest release" src="https://img.shields.io/github/v/release/Duoasa/QuotaView?display_name=tag"></a>
   <a href="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml"><img alt="CI status" src="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111?logo=apple">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white">
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Duoasa/QuotaView/releases/download/v0.4.6-build.1/QuotaView-v0.4.6-build.1.zip"><strong>Download QuotaView v0.4.6 Build 1</strong></a>
+  <a href="https://github.com/Duoasa/QuotaView/releases/download/v0.4.6-build.2/QuotaView-v0.4.6-build.2.zip"><strong>Download QuotaView v0.4.6 Build 2</strong></a>
   ·
   <a href="#get-started">Get started</a>
   ·
@@ -42,7 +42,9 @@ Codex can keep working after its window leaves the foreground, but its state sho
 
 QuotaView is open source, lightweight, and local-first. Current Codex releases work on first launch with no Hook setup. Quota and usage stay one click away in the menu panel and native widgets.
 
-## What's new in 0.4.6
+## What's new in 0.4.6 Build 2
+
+Brighter Quantum Noise with natural star clusters for thinking and context compaction, one curved working pulse with variable speed, warm golden confirmation breathing, and a softly dissolving progress edge from the start. The original particle size and density are preserved.
 
 More accurate Codex turn token counts and task progress. Internal reviews and background tasks no longer cause premature completion receipts; progress and token recovery remain consistent across task changes and restarts.
 
@@ -90,12 +92,12 @@ The Island leads the experience, while the rest of QuotaView provides the contex
 ## Get started
 
 1. Make sure ChatGPT or Codex is installed and signed in.
-2. Download `QuotaView-v0.4.6-build.1.zip` from the [v0.4.6 Build 1 release](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.1).
+2. Download `QuotaView-v0.4.6-build.2.zip` from the [v0.4.6 Build 2 release](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.2).
 3. Unzip it and open `QuotaView.app`.
 4. Start a Codex task. Current Codex releases connect automatically; no Hook installation or restart is required.
 
 > [!IMPORTANT]
-> v0.4.6 Build 1 is signed with a Developer ID certificate, notarized by Apple,
+> v0.4.6 Build 2 is signed with a Developer ID certificate, notarized by Apple,
 > and stapled for offline Gatekeeper verification. It opens normally after
 > unzipping, without the Finder right-click workaround used by older unsigned
 > builds.
@@ -218,7 +220,7 @@ Tests/
 
 ## Releases and project status
 
-- **Recommended stable:** [QuotaView v0.4.6 Build 1](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.1)
+- **Recommended stable:** [QuotaView v0.4.6 Build 2](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.2)
 - **Experimental multi-task preview:** [QuotaView v0.3.2 Preview 1](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.2-preview.1)
 - **Release history and verification:** [VERSION_HISTORY.md](VERSION_HISTORY.md)
 - **Current engineering handoff:** [HANDOFF.md](HANDOFF.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.1"><img alt="最新版本" src="https://img.shields.io/github/v/release/Duoasa/QuotaView?display_name=tag"></a>
+  <a href="https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.2"><img alt="最新版本" src="https://img.shields.io/github/v/release/Duoasa/QuotaView?display_name=tag"></a>
   <a href="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml"><img alt="CI 状态" src="https://github.com/Duoasa/QuotaView/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="macOS 14+" src="https://img.shields.io/badge/macOS-14%2B-111111?logo=apple">
   <img alt="Swift 6" src="https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white">
@@ -21,7 +21,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/Duoasa/QuotaView/releases/download/v0.4.6-build.1/QuotaView-v0.4.6-build.1.zip"><strong>下载 QuotaView v0.4.6 Build 1</strong></a>
+  <a href="https://github.com/Duoasa/QuotaView/releases/download/v0.4.6-build.2/QuotaView-v0.4.6-build.2.zip"><strong>下载 QuotaView v0.4.6 Build 2</strong></a>
   ·
   <a href="#快速开始">快速开始</a>
   ·
@@ -42,7 +42,9 @@
 
 QuotaView 开源、轻量，并以本地处理为核心。新版 Codex 首次启动即可使用，无需配置 Hook；额度与用量则保留在菜单面板和原生小组件中，需要时一次点击即可查看。
 
-## 0.4.6 更新
+## 0.4.6 Build 2 更新
+
+量子噪点更明亮鲜明：思考与压缩自然聚簇，执行使用单个非匀速弯曲脉冲，待确认保留暖金呼吸。从进度开始就以稀疏渐隐表达模糊末端，保留原版星点尺寸与疏密。
 
 改善 Codex 本轮 Token 统计与任务进度：修复内部审核、后台任务导致的提前完成回执，并保持任务切换和重启后的进度与 Token 恢复一致。
 
@@ -90,12 +92,12 @@ QuotaView 0.4.5 为新版 Codex 增加了只读本地任务桥：
 ## 快速开始
 
 1. 确认已经安装并登录 ChatGPT 或 Codex。
-2. 从 [v0.4.6 Build 1 Release](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.1) 下载 `QuotaView-v0.4.6-build.1.zip`。
+2. 从 [v0.4.6 Build 2 Release](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.2) 下载 `QuotaView-v0.4.6-build.2.zip`。
 3. 解压后打开 `QuotaView.app`。
 4. 开始一个 Codex 任务。新版 Codex 会自动连接，不需要安装 Hook 或重启。
 
 > [!IMPORTANT]
-> v0.4.6 Build 1 已使用 Developer ID 证书签名、通过 Apple 公证并完成
+> v0.4.6 Build 2 已使用 Developer ID 证书签名、通过 Apple 公证并完成
 > Staple。解压后可以正常打开，不再需要旧版未签名构建使用的 Finder
 > 右键打开方式。
 
@@ -217,7 +219,7 @@ Tests/
 
 ## 发布与项目状态
 
-- **推荐稳定版：** [QuotaView v0.4.6 Build 1](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.1)
+- **推荐稳定版：** [QuotaView v0.4.6 Build 2](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.2)
 - **实验性多任务预览：** [QuotaView v0.3.2 Preview 1](https://github.com/Duoasa/QuotaView/releases/tag/v0.3.2-preview.1)
 - **版本历史与发布验证：** [VERSION_HISTORY.md](VERSION_HISTORY.md)
 - **当前工程交接：** [HANDOFF.md](HANDOFF.md)

--- a/VERSION_HISTORY.md
+++ b/VERSION_HISTORY.md
@@ -15,29 +15,31 @@
 
 | 项目 | 当前值 |
 |---|---|
-| 最新推荐版本 | `0.4.6 (Build 1)`；Sparkle 内部 Build `18` |
-| Git tag | `v0.4.6-build.1` |
-| Tag commit | `2b071bea2f0af6fc4de042cf25084fc8524133d9` |
-| GitHub Release | [QuotaView 0.4.6 Build 1 — Reliable Codex Task Progress](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.1) |
-| Release 资产 | `QuotaView-v0.4.6-build.1.zip` |
-| 资产大小 | `13,564,435 bytes` |
-| SHA-256 | `00bf1a23d4424de534538871e667681ee7f27b5e475a7052e34d73cc06548174` |
+| 最新推荐版本 | `0.4.6 (Build 2)`；Sparkle 内部 Build `19` |
+| Git tag | `v0.4.6-build.2` |
+| Tag commit | `ae9f17d415fb1968d9ef843be771b6a5211213c7` |
+| GitHub Release | [QuotaView 0.4.6 Build 2 — Expressive Quantum Noise](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.2) |
+| Release 资产 | `QuotaView-v0.4.6-build.2.zip` |
+| 资产大小 | `13,487,447 bytes` |
+| SHA-256 | `5037b6318284364edd6ae7e26d4a1c4409b9ed182a425047af2af8f751f4f916` |
 | 最低系统版本 | macOS 14 |
 | 架构 | Universal `arm64 + x86_64` |
-| 签名 | `Developer ID Application: Chenchen Xu (BUUH229D5Q)`，证书 SHA-1 `E52D0A9C7C377AF77C484155CC0CFCFB27D949D3`，启用 Hardened Runtime |
-| 公证 | Apple Accepted，已 Staple；Submission `456d3e31-7c35-4cca-8db1-4538abca1d6a` |
+| 签名 | Developer ID `Chenchen Xu (BUUH229D5Q)`；证书 `E52D0A9C7C377AF77C484155CC0CFCFB27D949D3`；Hardened Runtime |
+| 公证 | Apple Accepted 并 Staple；Submission `f466177a-2fea-4e61-9c11-1e405ed32bde` |
 | 发布状态 | 正式 Release、Latest、非 Draft、非 Pre-release |
-| 自动更新 Feed | [公开 appcast](https://duoasa.github.io/QuotaView/appcast.xml)；`gh-pages` 提交 `81a16a81183cc854b97962d3a9fef613fbcc3344`；Feed SHA-256 `c28fb25f46501d027f58595886909f3b3663d4461bde433fd190318cd76768ca`；线上文件逐字节一致，Feed 与 ZIP 均以应用内公钥通过 Ed25519 验证 |
+| 自动更新 Feed | [公开 appcast](https://duoasa.github.io/QuotaView/appcast.xml)；提交 `94ae0ec0d63d4a50f77ba3a836afc98d2cb1009d`；SHA-256 `de8c07cc356ebf5d0c813a8e3fbd97703e879343a839a38fc30419bd4a118dce`；线上文件与本地一致，Feed 与回下载 ZIP 均通过内置公钥 Ed25519 验证 |
 
 上一稳定回滚基线：
 
 | 项目 | 封存值 |
 |---|---|
-| 版本 | `0.4.5 (Build 1)`；Sparkle 内部 Build `17` |
-| tag / commit | `v0.4.5-build.1` / `75913c07e4457b5f6451f286522799d36982ff0c` |
-| Release | [QuotaView 0.4.5 Build 1 — Native Codex Activity Bridge](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.5-build.1) |
-| 资产 / SHA-256 | `QuotaView-v0.4.5-build.1.zip` / `d5308880d9dc096e46cdbf715db414ae79a4bc92a1dcc4f433d315a6a7bd7e5a` |
-| 状态 | 不可移动历史正式版；发生 0.4.6 回滚时使用该 tag 与已核验资产 |
+| 版本 | `0.4.6 (Build 1)`；内部 `18` |
+| tag / commit | `v0.4.6-build.1` / `2b071bea2f0af6fc4de042cf25084fc8524133d9` |
+| Release | [QuotaView 0.4.6 Build 1](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.1) |
+| 资产 / 大小 | `QuotaView-v0.4.6-build.1.zip` / `13,564,435 bytes` |
+| SHA-256 | `00bf1a23d4424de534538871e667681ee7f27b5e475a7052e34d73cc06548174` |
+| 签名与公证 | Developer ID / Hardened Runtime；Apple Accepted / Staple，详见 Build 1 章节 |
+| 状态 | 不可移动历史正式版；Build 2 的回滚基线，仍保留在 Stable appcast |
 
 当前公开预览版：
 
@@ -56,10 +58,10 @@
 | 公证 | Apple Accepted，已 Staple；Submission `47c6d413-465f-4632-b7d2-1e48ed03f9a0` |
 | 发布状态 | GitHub Pre-release、非 Draft、非 Latest |
 
-> 当前生产版本为 `0.4.6 (Build 1)`。本版修复内部审核与后台任务导致的
-> 提前完成回执，统一任务身份、进度与真实终态，并改善新版 Codex Token
-> 计数及重启恢复。正式签名、公证/Staple、GitHub Latest、回下载与公开
-> appcast 签名验证已完成；详细证据见本文件的 `0.4.6 (Build 1)` 章节。
+> 当前生产版本为 `0.4.6 (Build 2)`，作为 Build 1 的量子噪点动效热更新。
+> 思考与压缩使用自然聚簇运动并保留各自配色，执行使用单个非匀速脉冲，
+> 等待保留暖金呼吸，低进度末端也保持稀疏渐隐。真实任务生命周期与近似
+> 进度来源保持不变。发布和验证证据见本文件 Build 2 章节。
 
 > 未发布开发版本不在本历史文件登记；当前迭代身份与验证状态只以
 > [HANDOFF.md](HANDOFF.md) 为准，不得把候选版本提前写成已发布。
@@ -75,7 +77,8 @@
 
 | 版本 | 日期（Asia/Shanghai） | 状态 | 核心定位 |
 |---|---|---|---|
-| `0.4.6 (Build 1)` | 2026-09-05 | **当前最新** | 可靠的任务归属、真实完成与 Codex Token 恢复 |
+| `0.4.6 (Build 2)` | 2026-09-06 | **当前最新** | 自然聚簇、非匀速脉冲与低进度渐隐的量子噪点热更新 |
+| `0.4.6 (Build 1)` | 2026-09-05 | 历史正式版 / Build 2 回滚基线 | 可靠的任务归属、真实完成与 Codex Token 恢复 |
 | `0.4.5 (Build 1)` | 2026-09-04 | 历史正式版 / 0.4.6 回滚基线 | 只读本地任务流数据桥、无需 Hook 的开箱连接与状态灵动岛升级 |
 | `0.4.3 (Build 1)` | 2026-09-03 | 历史正式版 / 0.4.5 回滚基线 | 量子噪点连续换色、更清晰的文字与统一完成辉光 |
 | `0.4.2 (Build 1)` | 2026-08-30 | 历史正式版 | 四种进度效果、真实设置预览与可靠的任务连续性 |
@@ -95,12 +98,52 @@
 | `0.1.3` | 2026-07-26 | 历史正式版 | 设置、外观、语言、图标和发布流程完善 |
 | `0.1.0` | 2026-07-26 | 首个公开版本 | Codex 额度、Credits、Token 与重置时间基础能力 |
 
+## 0.4.6 (Build 2)
+
+Tag：`v0.4.6-build.2`；发布提交：`ae9f17d415fb1968d9ef843be771b6a5211213c7`（[PR #47](https://github.com/Duoasa/QuotaView/pull/47)）。
+状态：当前最新正式 Release、GitHub Latest、非 Draft、非 Pre-release；
+已进入 Stable appcast，作为同版本 Build 1 的热更新。
+
+主要特性：
+
+- 保留原版星点的细度、尺寸、疏密和间隙，提高亮度与彩色状态鲜明度。
+- 思考态保留蓝紫色，使用自然聚簇、散开再汇聚；上下文压缩保留银白色聚簇。
+- 执行态使用单个弯曲且非匀速的脉冲；待确认保持原版可见暖金色与呼吸闪烁。
+- 所有状态在低进度起始阶段也保留稀疏、不规则渐隐末端，避免暗示精确进度。
+- 状态切换连续插值，不重启粒子时钟；真实状态、近似进度、完成时序、
+  Reduce Motion、其他三种特效、设置兼容与隐私边界保持原实现。
+- 独立 DEBUG 控制台保留在本地，未进入发布提交或生产 Target。
+
+验证与分发：
+
+- 本地与 [GitHub CI](https://github.com/Duoasa/QuotaView/actions/runs/34018170849)
+  均为 177 项测试、0 失败，包含生产 Metal/GPU 回归。
+- Universal Release：App、Widget、Hook 及框架均为 `arm64 x86_64`；
+  App / Widget 为 `0.4.6`、产品 Build `2`、内部 `19`；图标与资源齐全。
+- ZIP：`QuotaView-v0.4.6-build.2.zip`，`13,487,447 bytes`；SHA-256 `5037b6318284364edd6ae7e26d4a1c4409b9ed182a425047af2af8f751f4f916`。
+- Developer ID `Chenchen Xu (BUUH229D5Q)`，证书 SHA-1
+  `E52D0A9C7C377AF77C484155CC0CFCFB27D949D3`，Hardened Runtime。
+- Apple Accepted / Staple，Submission `f466177a-2fea-4e61-9c11-1e405ed32bde`。
+  清理封票后出现的 FinderInfo 非代码元数据，最终 ZIP 不携带扩展属性；
+  `dist`、最终解压副本及 GitHub 回下载副本的严格签名、票据与 Gatekeeper 均通过。
+- GitHub 回下载 ZIP 与本地逐字节一致；从回下载包启动通过，确认仅一份正式实例运行。
+- appcast 提交 `94ae0ec0d63d4a50f77ba3a836afc98d2cb1009d`，SHA-256 `de8c07cc356ebf5d0c813a8e3fbd97703e879343a839a38fc30419bd4a118dce`；线上文件逐字节一致。
+  Feed 与回下载 ZIP 均使用应用内置公钥通过 Ed25519 验证；更新序列为 `19 → 18 → 17`。
+- 用户已验收真实 Codex 压缩及随后思考动效，并明确批准 GitHub、appcast 和 Apple 公证。
+  完整外观/语言/辅助功能矩阵与旧客户端实际 N → N+1 安装仍未记录为通过。
+- 单份英文 Release Notes：`docs/releases/QuotaView-0.4.6-build.2.md`。
+- 回滚：Build 1 不可变 tag、ZIP、签名和公证保留，不覆盖原资产。
+
+Release：[QuotaView 0.4.6 Build 2 — Expressive Quantum Noise](https://github.com/Duoasa/QuotaView/releases/tag/v0.4.6-build.2)。
+
+---
+
 ## 0.4.6 (Build 1)
 
 Tag：`v0.4.6-build.1`；发布提交：`2b071bea2f0af6fc4de042cf25084fc8524133d9`（PR #45）。
 
-状态：当前最新正式 Release、GitHub Latest、非 Draft、非 Pre-release；
-已进入公开 Stable appcast，替代 0.4.5 Build 1。
+状态：历史正式 Release、Build 2 回滚基线、非 Draft、非 Pre-release；
+仍保留在 Stable appcast，最新版本已由 0.4.6 Build 2 替代。
 
 主要特性：
 

--- a/docs/design/quotaview-quantum-motion-console.md
+++ b/docs/design/quotaview-quantum-motion-console.md
@@ -2,10 +2,11 @@
 
 Spec ID: `QV-PROTOTYPE-QUANTUM-MOTION-016`
 
-Status: `Accepted / Verifying` — the owner has authorized production migration
+Status: `Accepted / Released` — the owner has authorized production migration
 into 0.4.6 Build 2. Local build and smoke checks passed. The owner accepted the production
 effect and authorized the Build 2 hot update on GitHub and appcast on 2026-09-06.
-Publication is being verified. Earlier sections record console iteration history.
+GitHub Latest, the notarized public archive and the signed Stable appcast are verified.
+Earlier sections record console iteration history; the console itself remains local.
 
 ## Requirements
 
@@ -193,3 +194,12 @@ The final source passes all 177 tests and a Universal Release build. No runtime
 mock, manual progress injection or console entry point is included in production.
 The full appearance, language and accessibility matrix remains a separate check;
 the owner's acceptance here covers the demonstrated activity effect.
+
+## Release verification · 2026-09-06
+
+Published as 0.4.6 Build 2 (internal 19), tag `v0.4.6-build.2`. All 177 local and
+GitHub CI tests pass. Universal production packaging, Developer ID / Hardened Runtime,
+Apple notarization / Staple, strict signatures, Gatekeeper and public-download launch
+checks pass. The public ZIP matches the final local archive byte for byte; both the
+public feed and ZIP verify with the packaged public key. Full immutable evidence and
+Build 1 rollback details are in [Version History](../../VERSION_HISTORY.md#当前最新版本).

--- a/docs/releases/QuotaView-0.4.6-build.2.md
+++ b/docs/releases/QuotaView-0.4.6-build.2.md
@@ -1,0 +1,17 @@
+A visual hot update for QuotaView 0.4.6 Build 1, with more expressive Quantum Noise and smoother state transitions.
+
+- Thinking keeps its blue-violet colors while stars naturally gather into clusters, disperse, and gather again. Context compaction uses the same motion in silver.
+- Working uses a single curved pulse that accelerates and slows down. Waiting for confirmation retains warm golden sparkle with gentle breathing.
+- Brighter, more vivid stars preserve the original fine particle size and density.
+- Progress dissolves into a sparse, irregular edge even at the start of a task, so estimated progress does not look exact.
+
+Real Codex activity, conservative progress, task completion behavior, existing settings and the other progress effects remain unchanged. This update includes no demo controls or simulated activity.
+
+macOS 14 or later. Universal app for Apple silicon and Intel. Product version **0.4.6 (Build 2)**; internal update version **19**.
+
+Signed with Developer ID, notarized by Apple, and stapled. All 177 local and GitHub CI tests pass; final archive and extracted-app signing, notarization and Gatekeeper checks pass.
+
+**SHA-256** (`QuotaView-v0.4.6-build.2.zip`):
+```
+5037b6318284364edd6ae7e26d4a1c4409b9ed182a425047af2af8f751f4f916
+```

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -4,9 +4,9 @@
 >
 > 状态：`Accepted`
 >
-> 生产基线：`0.4.6 Build 1`（内部 `18`）
+> 生产基线：`0.4.6 Build 2`（内部 `19`）
 >
-> 当前候选：`0.4.6 Build 2`（内部 `19`）；用户已验收，GitHub 与 appcast 热更新发布验证中
+> 当前候选：无；Build 2 已发布 GitHub Latest 与 Stable appcast
 
 本文件只负责规格发现和状态定位，不复制 Requirement、实现或发布证据。
 
@@ -14,7 +14,7 @@
 
 | Spec ID | 文档 | 状态 | 当前结论 |
 |---|---|---|---|
-| `QV-PROTOTYPE-QUANTUM-MOTION-016` | [量子噪点动效与控制台](../design/quotaview-quantum-motion-console.md) | `Accepted / Verifying` | 用户已授权迁入 0.4.6 Build 2；177 项生产测试、Universal、签名及启动检查通过；用户已验收并授权 GitHub 与 appcast 热更新，发布验证中 |
+| `QV-PROTOTYPE-QUANTUM-MOTION-016` | [量子噪点动效与控制台](../design/quotaview-quantum-motion-console.md) | `Accepted / Released` | 用户已验收当前效果；177 项本地及 CI 测试、Universal、签名、公证、回下载与线上 appcast 验证完成；0.4.6 Build 2 已发布 |
 | `QV-FIX-CODEX-TOKEN-COMPATIBILITY-015` | [0.4.6 Token 兼容修复](../design/quotaview-codex-token-compatibility-0.4.6.md) | `Accepted / Released` | [链路审计](../design/quotaview-activity-logic-audit-0.4.6.md)的 9 个场景已修复；[重构验证](../design/quotaview-activity-refactor-verification-0.4.6.md)本地及 CI 166 项测试通过，用户已确认真实五步视觉；正式签名、公证、Latest 与 appcast 已验证 |
 | `QV-RELEASE-0.4.5-001` | [0.4.5 Build 1 发布](../design/quotaview-0.4.5-release.md) | `Accepted / Released` | 130 项测试、Universal Developer ID、公证/Staple、GitHub Latest、回下载验证与 Stable appcast 在线 EdDSA 均已完成 |
 | `QV-PRODUCT-ACTIVITY-ISLAND-CONFIRMATION-REMINDER-014` | [0.4.5 灵动岛等待确认提醒](../design/quotaview-activity-island-confirmation-reminder-0.4.5.md) | `Accepted / Released` | 等待确认满 10 秒显示静态黄色描边和四周光晕；已随 0.4.5 发布 |


### PR DESCRIPTION
## Summary

Point the English and Simplified Chinese download entries to the published 0.4.6 Build 2 hot update and record its immutable release evidence. Keep Build 1 as the rollback baseline and preserve earlier release history.

## Specification

- Spec ID: `QV-PROTOTYPE-QUANTUM-MOTION-016`
- Spec state: Accepted. Delivery state: Released.
- Spec impact: Updated delivery status and owner acceptance; no requirement or application changes.

## Scope

Markdown only: release notes, version history, handoff, specification index and bilingual READMEs. No source, resource, configuration or build-script changes.

## Verification

- Version 0.4.6 / display Build 2 / internal 19 and immutable tag commit match the published app.
- GitHub Latest asset is 13,487,447 bytes; SHA-256 `5037b6318284364edd6ae7e26d4a1c4409b9ed182a425047af2af8f751f4f916`.
- Apple Accepted / Staple, Developer ID / Hardened Runtime, strict signatures and Gatekeeper pass for the final and public-download artifacts.
- GitHub download is byte-identical; downloaded app launch is verified with one QuotaView process.
- Public appcast is byte-identical to the signed feed at gh-pages commit `94ae0ec0d63d4a50f77ba3a836afc98d2cb1009d`. Feed and ZIP verify with the packaged public key.
- Release Notes match one English source; bilingual links, documentation backlinks and relative links pass. `git diff --check` passes.
- No repeat local build/tests for this Markdown-only change. Release-source local and GitHub CI suites each passed 177 tests.
- Owner acceptance covers the observed activity effect; full manual accessibility/appearance coverage and an actual old-client update installation remain explicitly unverified.

## Compatibility and privacy

No runtime or protocol changes. The local DEBUG console remains untracked and is not part of the release.

## Release impact

Synchronizes already-published Build 2 facts and public download pointers. Build 1 remains an immutable rollback artifact; tag and ZIP are not rewritten.
